### PR TITLE
Fix an error on installing latest Python when pyenv is not latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Here is English version of [README](./README_en.md).
 
 | プラットフォーム | CPUアーキテクチャー | OSバージョン |
 | :--- | :--- | :--- |
-| macOS | x86_64 (Intel), ARM64 (Apple Silicon) | Monterey, Ventura, Sonoma |
+| macOS | x86_64 (Intel), ARM64 (Apple Silicon) | Ventura, Sonoma |
 
 ## プログラミング言語
 現時点で、本スクリプトが対象としているプログラミング言語は、Pythonのみです。
@@ -37,7 +37,7 @@ git clone https://github.com/hotani3/start-code.git
 
 まだgitコマンドがインストール済みでないときは、[Releases](https://github.com/hotani3/start-code/releases)からZIPファイルをダウンロードし、展開します。
 ```sh
-unzip start-code-1.0.1.zip && mv start-code-1.0.1 start-code
+unzip start-code-1.0.2.zip && mv start-code-1.0.2 start-code
 ```
 
 次に、クローンまたはZIP展開したディレクトリに移動します。

--- a/README_en.md
+++ b/README_en.md
@@ -18,7 +18,7 @@ Currently, the only platform that has been tested is macOS.
 
 | Platform | CPU Architecture | OS Version |
 | :--- | :--- | :--- |
-| macOS | x86_64 (Intel), ARM64 (Apple Silicon) | Monterey, Ventura, Sonoma |
+| macOS | x86_64 (Intel), ARM64 (Apple Silicon) | Ventura, Sonoma |
 
 ## Programming Language
 At present, these scripts are targeted only for Python.
@@ -37,7 +37,7 @@ git clone https://github.com/hotani3/start-code.git
 
 If the git command is not installed, download the ZIP file from [Releases](https://github.com/hotani3/start-code/releases) and extract it.
 ```sh
-unzip start-code-1.0.1.zip && mv start-code-1.0.1 start-code
+unzip start-code-1.0.2.zip && mv start-code-1.0.2 start-code
 ```
 
 Next, move to the directory that was cloned or extracted from the ZIP.

--- a/macos/lib/constants.sh
+++ b/macos/lib/constants.sh
@@ -1,5 +1,5 @@
 #!/bin/zsh
-readonly SCRIPT_VERSION="1.0.1"
+readonly SCRIPT_VERSION="1.0.2"
 
 readonly DEFAULT_PYTHON_VERSION="3.12.6"
 readonly CPU_ARCH=$(uname -m)

--- a/macos/lib/pyenv.sh
+++ b/macos/lib/pyenv.sh
@@ -40,4 +40,7 @@ if [ $? -ne 0 ]; then
   source ~/.zshrc
 
   detect $package_title $detect_cmd $version_cmd true
+else
+  execute "Updating pyenv..." \
+          "brew update && brew upgrade pyenv" "Failed to update pyenv"
 fi


### PR DESCRIPTION
In addition, drop support for macOS Monterey because Homebrew doesn't support any more.