### PR TITLE
Release v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,21 @@ Here is English version of [README](./README_en.md).
 ## システム要件
 現時点で、動作確認を行なっているプラットフォームはmacOSのみです。
 
-| プラットフォーム | CPUアーキテクチャー | OSバージョン |
-| :--- | :--- | :--- |
-| macOS | x86_64 (Intel), ARM64 (Apple Silicon) | Ventura, Sonoma |
+表1: 対象プラットフォーム
+| プラットフォーム | CPUアーキテクチャー | OSバージョン | シェル |
+| :--- | :--- | :--- | :--- |
+| macOS | x86_64 (Intel Chip), ARM64 (Apple Silicon) | Ventura, Sonoma, Sequoia | zsh |
 
 ## プログラミング言語
-現時点で、本スクリプトが対象としているプログラミング言語は、Pythonのみです。
+現時点で、本スクリプトが対象としているプログラミング言語は、JavaScriptとPythonです。
 
 各言語のバージョン管理ツール、パッケージ管理ツールは次の通りです。バージョン管理ツールは、言語ごとに標準的なものを1つ選択しています。
 
-| 言語 | バージョン管理ツール | 実行環境バージョン | パッケージ管理ツール |
-| :--- | :--- | :--- | :--- |
-| Python | pyenv | 3.9.x, 3.10.x, 3.11.x, 3.12.x | venv+pip, Pipenv, Poetry |
+表2: 対象プログラミング言語
+| 言語 | バージョン管理ツール | 実行環境バージョン | デフォルトバージョン | パッケージ管理ツール |
+| :--- | :--- | :--- | :--- | :--- |
+| JavaScript | nvm | Node.js 20, 22, 23 | 22.11.0 | npm |
+| Python | pyenv | 3.9, 3.10, 3.11, 3.12, 3.13 | 3.12.7 | venv+pip, Pipenv, Poetry |
 
 ## 実行方法
 まず最初に、macOSのターミナルを開き、本リポジトリをクローンします。
@@ -37,7 +40,7 @@ git clone https://github.com/hotani3/start-code.git
 
 まだgitコマンドがインストール済みでないときは、[Releases](https://github.com/hotani3/start-code/releases)からZIPファイルをダウンロードし、展開します。
 ```sh
-unzip start-code-1.0.2.zip && mv start-code-1.0.2 start-code
+unzip start-code-1.1.0.zip && mv start-code-1.1.0 start-code
 ```
 
 次に、クローンまたはZIP展開したディレクトリに移動します。
@@ -47,46 +50,70 @@ cd start-code
 
 そして、各言語のセットアップスクリプトを実行します。  
 スクリプトは必ず、「start-code」ディレクトリにいる状態で実行してください。
-```sh
-./macos/install/python.sh -v 3.12.6
-```
 
 `-v`オプションで開発・実行環境バージョンが指定可能です。  
-指定しなかった場合は、Python 3.12.6がインストールされます。
+指定しなかった場合は、表2のデフォルトバージョンがインストールされます。
+
+#### JavaScript
+```sh
+./macos/install/javascript-node.sh -v 22.11.0
+```
+
+JavaScriptでは、`-v`オプションはNode.js実行環境のバージョンです。  
+バージョン番号に加えて、`stable`（安定版最新）, `lts/*`（LTS版最新）, `lts/iron`（LTS20系最新）, `lts/jod`（LTS22系最新）といったエイリアス（別名）指定も可能です。
+
+#### Python
+```sh
+./macos/install/python.sh -v 3.12.7
+```
 
 スクリプト実行直後、次のようにパスワード入力を促されたときは、Macログインユーザーのパスワードを入力してください。
 
 <img src="./images/password-prompt.png" width="800px" alt="パスワード入力" />
 
-しばらく待ち、ターミナルに以下のようなログが出力されれば、Python実行環境のインストールに成功しています。
+しばらく待ち、ターミナルに以下のようなログが出力されれば、開発・実行環境のインストールに成功しています。
 ```sh
 [2024-09-03 22:57:35] INFO python.sh: Successfully installed Python!
-[2024-09-03 22:57:36] INFO python.sh: Detected Python 3.12.6
+[2024-09-03 22:57:36] INFO python.sh: Detected Python 3.12.7
 ```
 
 Python標準のvenv+pipではなく、PipenvやPoetryでパッケージ管理を行う場合は、`python.sh`の代わりに、次のスクリプトを実行してください。
 
 #### Pipenv
 ```sh
-./macos/install/python-pipenv.sh -v 3.12.6
+./macos/install/python-pipenv.sh -v 3.12.7
 ```
 
 #### Poetry
 ```sh
-./macos/install/python-poetry.sh -v 3.12.6
+./macos/install/python-poetry.sh -v 3.12.7
 ```
 
-上記の例では、Python 3.12.6がインストールされ、さらにPipenvまたはPoetryがインストールされます。  
+上記の例では、Python 3.12.7がインストールされ、さらにPipenvまたはPoetryがインストールされます。  
 いずれの場合も、`-v`オプションはPython実行環境のバージョンです。PipenvやPoetryのバージョンではないことに注意してください。
 
 なお、Pipenvは`-v`で指定されたバージョンに加えて、`pyenv global`で指定された現在選択中のバージョンにもインストールされます。
 
-スクリプト実行後、ターミナルで新規ウィンドウまたは新規タブを開くか、もしくは現在のターミナルで次のように`.zshrc`の再読み込みを行うと、各ツールが使えるようになります。
+**スクリプト実行後、ターミナルで新規ウィンドウまたは新規タブを開くか、もしくは現在のターミナルで次のように`.zshrc`の再読み込みを行うと、各ツールが使えるようになります。**
 ```sh
 source ~/.zshrc
 ```
 
-最後に、`pyenv`コマンドでインストールされたバージョン、および、現在選択中のバージョンを確認することをお勧めします。
+最後に、バージョン管理ツールでインストールされたバージョン、および、現在選択中のバージョンを確認することをお勧めします。
+#### JavaScript
+```sh
+nvm ls
+```
+
+初めてNode.js実行環境をインストールしたときの表示例です。
+```sh
+->     v22.11.0
+         system
+default -> 22.11.0 (-> v22.11.0)
+[後略]
+```
+
+#### Python
 ```sh
 pyenv versions
 ```
@@ -94,27 +121,25 @@ pyenv versions
 初めてPython実行環境をインストールしたときの表示例です。
 ```sh
   system
-* 3.12.6 (set by /Users/username/.pyenv/version)
+* 3.12.7 (set by /Users/username/.pyenv/version)
 ```
 
 ## 補足説明：追加・更新されるパッケージと設定ファイル
 本スクリプトを実行すると、バージョン管理ツール、開発・実行環境、パッケージ管理ツールの動作のため、必要に応じて以下のパッケージが自動でダウンロード、インストールされます。
 
-#### macOS
-- Xcode Command Line Tools
-- Homebrew
-- OpenSSL
-- XZ Utils
-
 加えて、環境変数やプログラム実行パスの設定を行うため、必要に応じて以下の設定ファイルも自動更新されます。
 
-#### macOS
-- ~/.zprofile
-- ~/.zshrc
+表3: 追加・更新対象のパッケージ・設定ファイル
+| プラットフォーム | パッケージ | 設定ファイル |
+| :--- | :--- | :--- |
+| macOS | <ul><li>Xcode Command Line Tools</li><li>Homebrew</li><li>OpenSSL</li><li>XZ Utils</li></ul> | <ul><li>~/.zprofile</li><li>~/.zshrc</li></ul> |
 
 このため、各ツールの動作に必要なパッケージの手動インストールや、環境変数の手動設定は不要です。
 
 ## 参考情報
+#### JavaScript
+- [nvm(Node Version Manager)を使ってNode.jsをインストールする手順](https://qiita.com/ffggss/items/94f1c4c5d311db2ec71a)
+
 #### Python
 - [pyenv, virtualenv, pipenv, poetry の概要](https://blog.serverworks.co.jp/pyenv-virtualenv-pipenv-poetry)
 - [Pipenvを使ったPython開発まとめ](https://qiita.com/y-tsutsu/items/54c10e0b2c6b565c887a)

--- a/README_en.md
+++ b/README_en.md
@@ -16,18 +16,21 @@ For these reasons, I created these scripts that allows you to easily set up thes
 ## System Requirements
 Currently, the only platform that has been tested is macOS.
 
-| Platform | CPU Architecture | OS Version |
-| :--- | :--- | :--- |
-| macOS | x86_64 (Intel), ARM64 (Apple Silicon) | Ventura, Sonoma |
+Table 1: Target Platforms
+| Platform | CPU Architecture | OS Version | Shell |
+| :--- | :--- | :--- | :--- |
+| macOS | x86_64 (Intel Chip), ARM64 (Apple Silicon) | Ventura, Sonoma, Sequoia | zsh |
 
 ## Programming Language
-At present, these scripts are targeted only for Python.
+At present, these scripts are targeted for JavaScript and Python.
 
-The version control tools and package management tools for each language are as follows. One standard version control tool has been chosen for each language.
+The version control tool and package management tools for each language are as follows. One standard version control tool has been chosen for each language.
 
-| Language | Version Control Tool | Runtime Version | Package Management Tool |
-| :--- | :--- | :--- | :--- |
-| Python | pyenv | 3.9.x, 3.10.x, 3.11.x, 3.12.x | venv+pip, Pipenv, Poetry |
+Table 2: Target Programming Languages
+| Language | Version Control Tool | Runtime Version | Default Version | Package Management Tool |
+| :--- | :--- | :--- | :--- | :--- |
+| Javascript | nvm | Node.js 20, 22, 23 | 22.11.0 | npm |
+| Python | pyenv | 3.9, 3.10, 3.11, 3.12 | 3.12.7 | venv+pip, Pipenv, Poetry |
 
 ## How to Execute
 First, open the macOS terminal and clone this repository.
@@ -37,7 +40,7 @@ git clone https://github.com/hotani3/start-code.git
 
 If the git command is not installed, download the ZIP file from [Releases](https://github.com/hotani3/start-code/releases) and extract it.
 ```sh
-unzip start-code-1.0.2.zip && mv start-code-1.0.2 start-code
+unzip start-code-1.1.0.zip && mv start-code-1.1.0 start-code
 ```
 
 Next, move to the directory that was cloned or extracted from the ZIP.
@@ -47,47 +50,71 @@ cd start-code
 
 Then, execute a setup script for each language.  
 Be sure to run a script while you are in the "start-code" directory.
+
+You can specify a development or runtime environment version with the `-v` option.  
+If not specified, the default version in Table 2 will be installed.
+
+#### JavaScript
 ```sh
-./macos/install/python.sh -v 3.12.6
+./macos/install/javascript-node.sh -v 22.11.0
 ```
 
-You can specify the development and runtime environment version with the `-v` option.  
-If not specified, Python 3.12.6 will be installed.
+In JavaScript, the `-v` option is the version of the Node.js runtime environment.  
+In addition to the version number, you can also specify aliases such as `stable` (latest stable version), `lts/*` (latest LTS version), `lts/iron` (latest of LTS 20 series), and `lts/jod` (latest of LTS 22 series).
+
+#### Python
+```sh
+./macos/install/python.sh -v 3.12.7
+```
 
 Immediately after running the script, if you are prompted to enter a password as shown below, please enter your Mac login user's password.
 
 <img src="./images/password-prompt.png" width="800px" alt="Password Prompt" />
 
-Wait a moment, and if the following log is output to the terminal, the Python runtime environment has been successfully installed.
+Wait a moment, and if the following log is output to the terminal, a development or runtime environment has been successfully installed.
 ```sh
 [2024-09-03 22:57:35] INFO python.sh: Successfully installed Python!
-[2024-09-03 22:57:36] INFO python.sh: Detected Python 3.12.6
+[2024-09-03 22:57:36] INFO python.sh: Detected Python 3.12.7
 ```
 
 If you want to manage packages with Pipenv or Poetry instead of Python's standard venv+pip, run the following script instead of `python.sh`.
 
 #### Pipenv
 ```sh
-./macos/install/python-pipenv.sh -v 3.12.6
+./macos/install/python-pipenv.sh -v 3.12.7
 ```
 
 #### Poetry
 ```sh
-./macos/install/python-poetry.sh -v 3.12.6
+./macos/install/python-poetry.sh -v 3.12.7
 ```
 
-In the above examples, Python 3.12.6 will be installed, and additionally, Pipenv or Poetry will also be installed.  
+In the above examples, Python 3.12.7 will be installed, and additionally, Pipenv or Poetry will also be installed.  
 In all cases, the `-v` option is for specifying the Python runtime environment version, not the version of Pipenv or Poetry.
 
 Please note that for Pipenv, it will be installed for both the version specified with `-v` and the currently selected version as specified by `pyenv global`.
 
-After the script has finished running, open a new window or tab in the terminal, or reload `.zshrc` in the current terminal as shown below to start using the tools.
+**After the script has finished running, open a new window or tab in the terminal, or reload `.zshrc` in the current terminal as shown below to start using the tools.**
 
 ```sh
 source ~/.zshrc
 ```
 
-Finally, it is preferable to check the versions installed and currently selected with the `pyenv` command.
+Finally, it is preferable to check the versions installed and currently selected with a version control tool.
+#### JavaScript
+```sh
+nvm ls
+```
+
+Here is an example of what you see when you first install the Node.js runtime environment.
+```sh
+->     v22.11.0
+         system
+default -> 22.11.0 (-> v22.11.0)
+[The rest is ommitted]
+```
+
+#### Python
 ```sh
 pyenv versions
 ```
@@ -95,27 +122,25 @@ pyenv versions
 Here is an example of what you see when you first install the Python runtime environment.
 ```sh
   system
-* 3.12.6 (set by /Users/username/.pyenv/version)
+* 3.12.7 (set by /Users/username/.pyenv/version)
 ```
 
 ## Additional Notes: Packages and Configuration Files Added or Updated
 When these scripts are executed, the following packages will be automatically downloaded and installed as necessary to ensure the operation of version control tools, development and runtime environments, and package management tools.
 
-#### macOS
-- Xcode Command Line Tools
-- Homebrew
-- OpenSSL
-- XZ Utils
-
 Additionally, the following configuration files will be automatically updated as necessary to configure environment variables and program execution paths.
 
-#### macOS
-- ~/.zprofile
-- ~/.zshrc
+Table 3: Packages and Configuration Files to be Added or Updated
+| Platform | Package | Configuration File |
+| :--- | :--- | :--- |
+| macOS | <ul><li>Xcode Command Line Tools</li><li>Homebrew</li><li>OpenSSL</li><li>XZ Utils</li></ul> | <ul><li>~/.zprofile</li><li>~/.zshrc</li></ul> |
 
 Therefore, you don't have to install packages or set environment variables manually for each tool to work propery.
 
 ## Reference Information
+#### JavaScript
+- [Steps to install Node.js using nvm(Node Version Manager)](https://qiita.com/ffggss/items/94f1c4c5d311db2ec71a)
+
 #### Python
 - [Overview of pyenv, virtualenv, pipenv, poetry](https://blog.serverworks.co.jp/pyenv-virtualenv-pipenv-poetry)
 - [Summary of Python development with Pipenv](https://qiita.com/y-tsutsu/items/54c10e0b2c6b565c887a)

--- a/macos/install/javascript-node.sh
+++ b/macos/install/javascript-node.sh
@@ -1,0 +1,20 @@
+#!/bin/zsh
+readonly SCRIPT_NAME=$(basename $0)
+
+# Exit if not in start-code directory
+if [ ! -d "macos/install" ] || [ ! -d "macos/lib" ]; then
+  timestamp=$(date "+%Y-%m-%d %H:%M:%S")
+  echo "[$timestamp] ERROR $SCRIPT_NAME: Please run this script in the "\""start-code"\"" directory" >&2
+  exit 1
+fi
+
+source ./macos/lib/constants.sh
+source ./macos/lib/functions.sh
+
+timestamp=$(date "+%Y-%m-%d %H:%M:%S")
+echo "[$timestamp] INFO $SCRIPT_NAME $SCRIPT_VERSION: Running on macOS $MACOS_VERSION ($CPU_ARCH)"
+
+# nvm.sh requires the git command in Xcode CLT installed by homebrew.sh
+source ./macos/lib/homebrew.sh
+source ./macos/lib/nvm.sh
+source ./macos/lib/nvm-node.sh

--- a/macos/lib/constants.sh
+++ b/macos/lib/constants.sh
@@ -1,6 +1,9 @@
 #!/bin/zsh
-readonly SCRIPT_VERSION="1.0.2"
+readonly SCRIPT_VERSION="1.1.0"
+readonly NVM_VERSION="0.40.1"
 
-readonly DEFAULT_PYTHON_VERSION="3.12.6"
+readonly DEFAULT_PYTHON_VERSION="3.12.7"
+readonly DEFAULT_NODE_VERSION="22.11.0"
+
 readonly CPU_ARCH=$(uname -m)
 readonly MACOS_VERSION=$(sw_vers -productVersion)

--- a/macos/lib/functions.sh
+++ b/macos/lib/functions.sh
@@ -11,6 +11,36 @@ function assert_version_format() {
   fi
 }
 
+# Validate Node.js version number or alias format
+# nvm can accept a format like "stable" or "lts/*" or "lts/jod" or "22" or "22.11" or "22.11.0"
+function assert_node_version_alias() {
+  local version="$1"
+  local timestamp=""
+
+  # Refs: https://qiita.com/ko1nksm/items/3d1fd784611620b1bea5
+  if [[ ! $version =~ (stable|lts/[*]|lts/iron|lts/jod) ]] && [[ ! $version =~ ^[0-9]+(\.[0-9]+){0,2}$ ]]; then
+    timestamp=$(date "+%Y-%m-%d %H:%M:%S")
+    echo "[$timestamp] ERROR $SCRIPT_NAME: Invalid version format: $version" >&2
+    exit 1
+  fi
+}
+
+# Resolve Node.js version number from alias using "nvm ls-remote"
+function resolve_node_version() {
+  local alias="$1"
+  local version="$DEFAULT_NODE_VERSION"
+
+  if [ $alias = "stable" ]; then
+    version=$(nvm ls-remote --no-colors | tail -n 1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+  elif [[ $alias =~ (lts/[*]|lts/iron|lts/jod) ]] || [[ $alias =~ ^[0-9]+(\.[0-9]+){0,1}$ ]]; then
+    version=$(nvm ls-remote --no-colors "$alias" | tail -n 1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+  else
+    version="$alias"
+  fi
+
+  echo $version
+}
+
 function execute() {
   local start_msg="$1"
   local cmd="$2"

--- a/macos/lib/nvm-node.sh
+++ b/macos/lib/nvm-node.sh
@@ -1,0 +1,52 @@
+#!/bin/zsh
+
+# Get -v option value as Node.js version number or alias
+while getopts v: OPT
+do
+  case $OPT in
+    v) NODE_VERSION_ALIAS=$OPTARG ;;
+  esac
+done
+
+# If not specified in an arg, set default version
+if [ -z "$NODE_VERSION_ALIAS" ]; then
+  NODE_VERSION_ALIAS=$DEFAULT_NODE_VERSION
+fi
+
+# Validate version number or alias format
+assert_node_version_alias $NODE_VERSION_ALIAS
+NODE_VERSION=$(resolve_node_version $NODE_VERSION_ALIAS)
+
+package_title='Node.js'
+detect_cmd="nvm ls $NODE_VERSION | grep -q $NODE_VERSION"
+version_cmd="nvm ls $NODE_VERSION | grep -o $NODE_VERSION"
+install_cmd="nvm install $NODE_VERSION"
+detect $package_title $detect_cmd $version_cmd false
+if [ $? -ne 0 ]; then
+  install $package_title $install_cmd
+  detect $package_title $detect_cmd $version_cmd true
+fi
+
+# Check if node and npm are available on the current default Node.js version on nvm
+# This check fails when the version is "system", but Node.js is not installed on the system
+nvm use default >/dev/null 2>&1
+default_selected=$?
+
+package_title='current Node.js'
+detect_cmd="node -v >/dev/null 2>&1"
+# Remove the "v" prefix from a version string
+version_cmd='node -v | awk '\''{print substr($0, 2)}'\'''
+detect $package_title $detect_cmd $version_cmd false
+node_detected=$?
+
+package_title='current npm'
+detect_cmd="npm -v >/dev/null 2>&1"
+version_cmd='npm -v'
+detect $package_title $detect_cmd $version_cmd false
+npm_detected=$?
+
+# If node or npm is not available, switch to the installed Node.js version in nvm-node.sh
+if [ $default_selected -ne 0 ] || [ $node_detected -ne 0 ] || [ $npm_detected -ne 0 ]; then
+  execute "Switching default Node.js version to $NODE_VERSION on nvm" \
+          "nvm alias default $NODE_VERSION && nvm use default" "Failed to switch default Node.js version to $NODE_VERSION"
+fi

--- a/macos/lib/nvm.sh
+++ b/macos/lib/nvm.sh
@@ -1,0 +1,21 @@
+#!/bin/zsh
+
+# Enable the nvm command if already installed
+source ~/.zshrc
+
+package_title='nvm'
+detect_cmd='nvm --version >/dev/null 2>&1'
+version_cmd='nvm --version'
+# nvm does not support Homebrew installation
+install_cmd="curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v$NVM_VERSION/install.sh | bash"
+detect $package_title $detect_cmd $version_cmd false
+if [ $? -ne 0 ]; then
+  echo "# nvm" >> ~/.zshrc
+  install $package_title $install_cmd
+
+  # .zshrc is automatically updated by nvm install script
+  sync
+  source ~/.zshrc
+
+  detect $package_title $detect_cmd $version_cmd true
+fi

--- a/macos/lib/pyenv.sh
+++ b/macos/lib/pyenv.sh
@@ -3,7 +3,7 @@
 package_title='OpenSSL'
 detect_cmd='brew list --versions openssl@1.1 >/dev/null 2>&1'
 version_cmd='brew list --versions openssl@1.1 | awk '\''{print $2}'\'''
-install_cmd='brew install openssl@1.1'
+install_cmd='HOMEBREW_NO_INSTALL_CLEANUP=1 brew install openssl@1.1'
 detect $package_title $detect_cmd $version_cmd false
 if [ $? -ne 0 ]; then
   install $package_title $install_cmd
@@ -13,7 +13,7 @@ fi
 package_title='XZ Utils'
 detect_cmd='brew list --versions xz >/dev/null 2>&1'
 version_cmd='brew list --versions xz | awk '\''{print $2}'\'''
-install_cmd='brew install xz'
+install_cmd='HOMEBREW_NO_INSTALL_CLEANUP=1 brew install xz'
 detect $package_title $detect_cmd $version_cmd false
 if [ $? -ne 0 ]; then
   install $package_title $install_cmd
@@ -23,7 +23,7 @@ fi
 package_title='pyenv'
 detect_cmd='pyenv -v >/dev/null 2>&1'
 version_cmd='pyenv -v | awk '\''{print $2}'\'''
-install_cmd='brew install pyenv'
+install_cmd='HOMEBREW_NO_INSTALL_CLEANUP=1 brew install pyenv'
 detect $package_title $detect_cmd $version_cmd false
 if [ $? -ne 0 ]; then
   install $package_title $install_cmd
@@ -42,5 +42,5 @@ if [ $? -ne 0 ]; then
   detect $package_title $detect_cmd $version_cmd true
 else
   execute "Updating pyenv..." \
-          "brew update && brew upgrade pyenv" "Failed to update pyenv"
+          "brew update && HOMEBREW_NO_INSTALL_CLEANUP=1 brew upgrade pyenv" "Failed to update pyenv"
 fi


### PR DESCRIPTION
1. Add a workaround for `Permission denied @ apply2files - /usr/local/lib/docker/cli-plugins` error on `brew cleanup`
1. The following languages ​​and tools are now supported on macOS.

| Language | Version Control Tool | Runtime Version | Default Version | Package Management Tool |
| :--- | :--- | :--- | :--- | :--- |
| JavaScript | nvm | Node.js 20, 22, 23 | 22.11.0 | npm |
