### PR TITLE
Release v1.2.0

### DIFF
--- a/.github/workflows/ansible-on-macos.yml
+++ b/.github/workflows/ansible-on-macos.yml
@@ -1,0 +1,211 @@
+name: Ansible on macOS
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches-ignore:
+      - main
+  schedule:
+    - cron: '10 11 * * *'
+
+env:
+  # Overwrite the default shell to zsh
+  SHELL: /bin/zsh
+
+jobs:
+  test-on-macos-ventura-x86_64:
+    runs-on: macos-13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Ansible 2.17.0 against supported Python versions
+      - name: Install Ansible 2.17.0 with Python 3.10.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.10.0
+      - name: Install Ansible 2.17.0 with Python 3.10.17
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.10.17
+      - name: Install Ansible 2.17.0 with Python 3.11.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.11.12
+      - name: Install Ansible 2.17.0 with Python 3.12.10
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.12.10
+
+      # Ansible 2.17.11 against supported Python versions
+      - name: Install Ansible 2.17.11 with Python 3.10.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.11 --python 3.10.0
+      - name: Install Ansible 2.17.11 with Python 3.10.17
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.11 --python 3.10.17
+      - name: Install Ansible 2.17.11 with Python 3.11.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.11 --python 3.11.12
+      - name: Install Ansible 2.17.11 with Python 3.12.10
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.11 --python 3.12.10
+
+      # Ansible 2.18.5 against supported Python versions
+      - name: Install Ansible 2.18.5 with Python 3.11.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.5 --python 3.11.0
+      - name: Install Ansible 2.18.5 with Python 3.11.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.5 --python 3.11.12
+      - name: Install Ansible 2.18.5 with Python 3.12.10
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.5 --python 3.12.10
+      - name: Install Ansible 2.18.5 with Python 3.13.3
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.5 --python 3.13.3
+      
+      - name: List all Ansible versions
+        shell: zsh {0}
+        run: |
+          ls ~/envs
+
+  test-on-macos-sonoma-arm64:
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Ansible 2.17.0
+      - name: Install Ansible 2.17.0 with Python 3.10.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.10.0
+      - name: Install Ansible 2.17.0 with Python 3.10.17
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.10.17
+      - name: Install Ansible 2.17.0 with Python 3.11.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.11.12
+      - name: Install Ansible 2.17.0 with Python 3.12.10
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.12.10
+
+      # Ansible 2.17.11
+      - name: Install Ansible 2.17.11 with Python 3.10.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.11 --python 3.10.0
+      - name: Install Ansible 2.17.11 with Python 3.10.17
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.11 --python 3.10.17
+      - name: Install Ansible 2.17.11 with Python 3.11.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.11 --python 3.11.12
+      - name: Install Ansible 2.17.11 with Python 3.12.10
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.11 --python 3.12.10
+
+      # Ansible 2.18.5
+      - name: Install Ansible 2.18.5 with Python 3.11.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.5 --python 3.11.0
+      - name: Install Ansible 2.18.5 with Python 3.11.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.5 --python 3.11.12
+      - name: Install Ansible 2.18.5 with Python 3.12.10
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.5 --python 3.12.10
+      - name: Install Ansible 2.18.5 with Python 3.13.3
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.5 --python 3.13.3
+
+      - name: List all Ansible versions
+        shell: zsh {0}
+        run: |
+          ls ~/envs
+
+  test-on-macos-sequoia-arm64:
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Ansible 2.17.0
+      - name: Install Ansible 2.17.0 with Python 3.10.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.10.0
+      - name: Install Ansible 2.17.0 with Python 3.10.17
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.10.17
+      - name: Install Ansible 2.17.0 with Python 3.11.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.11.12
+      - name: Install Ansible 2.17.0 with Python 3.12.10
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.12.10
+
+      # Ansible 2.17.11
+      - name: Install Ansible 2.17.11 with Python 3.10.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.11 --python 3.10.0
+      - name: Install Ansible 2.17.11 with Python 3.10.17
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.11 --python 3.10.17
+      - name: Install Ansible 2.17.11 with Python 3.11.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.11 --python 3.11.12
+      - name: Install Ansible 2.17.11 with Python 3.12.10
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.11 --python 3.12.10
+
+      # Ansible 2.18.5
+      - name: Install Ansible 2.18.5 with Python 3.11.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.5 --python 3.11.0
+      - name: Install Ansible 2.18.5 with Python 3.11.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.5 --python 3.11.12
+      - name: Install Ansible 2.18.5 with Python 3.12.10
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.5 --python 3.12.10
+      - name: Install Ansible 2.18.5 with Python 3.13.3
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.5 --python 3.13.3
+
+      - name: List all Ansible versions
+        shell: zsh {0}
+        run: |
+          ls ~/envs

--- a/.github/workflows/javascript-on-macos.yml
+++ b/.github/workflows/javascript-on-macos.yml
@@ -26,18 +26,18 @@ jobs:
         shell: zsh {0}
         run: |
           ./macos/install/javascript-node.sh -v 20.0.0
-      - name: Install Node.js 20.18.1
+      - name: Install Node.js 20.19.1
         shell: zsh {0}
         run: |
-          ./macos/install/javascript-node.sh -v 20.18.1
-      - name: Install Node.js 22.12.0
+          ./macos/install/javascript-node.sh -v 20.19.1
+      - name: Install Node.js 22.15.0
         shell: zsh {0}
         run: |
-          ./macos/install/javascript-node.sh -v 22.12.0
-      - name: Install Node.js 23.5.0
+          ./macos/install/javascript-node.sh -v 22.15.0
+      - name: Install Node.js 23.11.0
         shell: zsh {0}
         run: |
-          ./macos/install/javascript-node.sh -v 23.5.0
+          ./macos/install/javascript-node.sh -v 23.11.0
       - name: List all Node.js versions
         shell: zsh {0}
         run: |
@@ -85,18 +85,76 @@ jobs:
         shell: zsh {0}
         run: |
           ./macos/install/javascript-node.sh -v 20.0.0
-      - name: Install Node.js 20.18.1
+      - name: Install Node.js 20.19.1
         shell: zsh {0}
         run: |
-          ./macos/install/javascript-node.sh -v 20.18.1
-      - name: Install Node.js 22.12.0
+          ./macos/install/javascript-node.sh -v 20.19.1
+      - name: Install Node.js 22.15.0
         shell: zsh {0}
         run: |
-          ./macos/install/javascript-node.sh -v 22.12.0
-      - name: Install Node.js 23.5.0
+          ./macos/install/javascript-node.sh -v 22.15.0
+      - name: Install Node.js 23.11.0
         shell: zsh {0}
         run: |
-          ./macos/install/javascript-node.sh -v 23.5.0
+          ./macos/install/javascript-node.sh -v 23.11.0
+      - name: List all Node.js versions
+        shell: zsh {0}
+        run: |
+          source ~/.zshrc
+          nvm ls
+      - name: Uninstall all versions
+        shell: zsh {0}
+        run: |
+          source ~/.zshrc
+          nvm deactivate
+          nvm ls --no-alias | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | while read -r version; do
+            nvm uninstall "$version"
+          done
+      - name: Install Node.js LTS iron
+        shell: zsh {0}
+        run: |
+          ./macos/install/javascript-node.sh -v lts/iron
+      - name: Install Node.js LTS jod
+        shell: zsh {0}
+        run: |
+          ./macos/install/javascript-node.sh -v lts/jod
+      - name: Install Node.js LTS latest
+        shell: zsh {0}
+        run: |
+          ./macos/install/javascript-node.sh -v 'lts/*'
+      - name: Install Node.js stable version
+        shell: zsh {0}
+        run: |
+          ./macos/install/javascript-node.sh -v stable
+      - name: List Node.js aliases
+        shell: zsh {0}
+        run: |
+          source ~/.zshrc
+          nvm ls
+
+  test-on-macos-sequoia-arm64:
+    runs-on: macos-15
+    steps:
+      # Checkout this repo
+      - name: Checkout
+        uses: actions/checkout@v4
+      # Run the script using zsh
+      - name: Install Node.js 20.0.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/javascript-node.sh -v 20.0.0
+      - name: Install Node.js 20.19.1
+        shell: zsh {0}
+        run: |
+          ./macos/install/javascript-node.sh -v 20.19.1
+      - name: Install Node.js 22.15.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/javascript-node.sh -v 22.15.0
+      - name: Install Node.js 23.11.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/javascript-node.sh -v 23.11.0
       - name: List all Node.js versions
         shell: zsh {0}
         run: |

--- a/.github/workflows/python-on-macos.yml
+++ b/.github/workflows/python-on-macos.yml
@@ -26,26 +26,26 @@ jobs:
         shell: zsh {0}
         run: |
           ./macos/install/python-pipenv.sh -v 3.9.1
-      - name: Install Python 3.9.21
+      - name: Install Python 3.9.22
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.9.21
-      - name: Install Python 3.10.16
+          ./macos/install/python-pipenv.sh -v 3.9.22
+      - name: Install Python 3.10.17
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.10.16
-      - name: Install Python 3.11.11
+          ./macos/install/python-pipenv.sh -v 3.10.17
+      - name: Install Python 3.11.12
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.11.11
-      - name: Install Python 3.12.8
+          ./macos/install/python-pipenv.sh -v 3.11.12
+      - name: Install Python 3.12.10
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.12.8
-      - name: Install Python 3.13.1
+          ./macos/install/python-pipenv.sh -v 3.12.10
+      - name: Install Python 3.13.3
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.13.1
+          ./macos/install/python-pipenv.sh -v 3.13.3
       - name: List all Python versions
         shell: zsh {0}
         run: |
@@ -60,10 +60,10 @@ jobs:
         run: |
           curl -sSL https://install.python-poetry.org | python3 - --uninstall
           unlink $HOME/.local/bin/poetry
-      - name: Install Poetry bound with Python 3.13.1
+      - name: Install Poetry bound with Python 3.13.3
         shell: zsh {0}
         run: |
-          ./macos/install/python-poetry.sh -v 3.13.1
+          ./macos/install/python-poetry.sh -v 3.13.3
  
   test-on-macos-sonoma-arm64:
     runs-on: macos-14
@@ -77,26 +77,26 @@ jobs:
         shell: zsh {0}
         run: |
           ./macos/install/python-pipenv.sh -v 3.9.1
-      - name: Install Python 3.9.21
+      - name: Install Python 3.9.22
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.9.21
-      - name: Install Python 3.10.16
+          ./macos/install/python-pipenv.sh -v 3.9.22
+      - name: Install Python 3.10.17
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.10.16
-      - name: Install Python 3.11.11
+          ./macos/install/python-pipenv.sh -v 3.10.17
+      - name: Install Python 3.11.12
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.11.11
-      - name: Install Python 3.12.8
+          ./macos/install/python-pipenv.sh -v 3.11.12
+      - name: Install Python 3.12.10
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.12.8
-      - name: Install Python 3.13.1
+          ./macos/install/python-pipenv.sh -v 3.12.10
+      - name: Install Python 3.13.3
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.13.1
+          ./macos/install/python-pipenv.sh -v 3.13.3
       - name: List all Python versions
         shell: zsh {0}
         run: |
@@ -111,7 +111,58 @@ jobs:
         run: |
           curl -sSL https://install.python-poetry.org | python3 - --uninstall
           unlink $HOME/.local/bin/poetry
-      - name: Install Poetry bound with Python 3.13.1
+      - name: Install Poetry bound with Python 3.13.3
         shell: zsh {0}
         run: |
-          ./macos/install/python-poetry.sh -v 3.13.1
+          ./macos/install/python-poetry.sh -v 3.13.3
+
+  test-on-macos-sequoia-arm64:
+    runs-on: macos-15
+    steps:
+      # Checkout this repo
+      - name: Checkout
+        uses: actions/checkout@v4
+      # Run the script using zsh
+      # 3.9.1 is the first version that supports Apple Silicon
+      - name: Install Python 3.9.1
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.9.1
+      - name: Install Python 3.9.22
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.9.22
+      - name: Install Python 3.10.17
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.10.17
+      - name: Install Python 3.11.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.11.12
+      - name: Install Python 3.12.10
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.12.10
+      - name: Install Python 3.13.3
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.13.3
+      - name: List all Python versions
+        shell: zsh {0}
+        run: |
+          source ~/.zshrc
+          pyenv versions
+      - name: Install Poetry bound with Python 3.9.1
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-poetry.sh -v 3.9.1
+      - name: Uninstall Poetry
+        shell: zsh {0}
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 - --uninstall
+          unlink $HOME/.local/bin/poetry
+      - name: Install Poetry bound with Python 3.13.3
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-poetry.sh -v 3.13.3

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![Ansible on macOS](https://github.com/hotani3/start-code/actions/workflows/ansible-on-macos.yml/badge.svg)&emsp;
 ![JavaScript on macOS](https://github.com/hotani3/start-code/actions/workflows/javascript-on-macos.yml/badge.svg)&emsp;
 ![Python on macOS](https://github.com/hotani3/start-code/actions/workflows/python-on-macos.yml/badge.svg)
 
@@ -25,15 +26,16 @@ Here is English version of [README](./README_en.md).
 | macOS | <ul><li>x86_64 (Intel Chip)</li><li>ARM64 (Apple Silicon)</li></ul> | <ul><li>Ventura (13)</li><li>Sonoma (14)</li><li>Sequoia (15)</li></ul> | zsh |
 
 ## プログラミング言語
-現時点で、本スクリプトが対象としているプログラミング言語は、JavaScriptとPythonです。
+現時点で、本スクリプトが対象としているプログラミング言語は、Ansible, JavaScript, Pythonです。
 
 各言語のバージョン管理ツール、パッケージ管理ツールは次の通りです。バージョン管理ツールは、言語ごとに標準的なものを1つ選択しています。
 
 表2: 対象プログラミング言語
 | 言語 | バージョン管理ツール | 実行環境バージョン | デフォルトバージョン | パッケージ管理ツール |
 | :--- | :--- | :--- | :--- | :--- |
-| JavaScript | nvm | Node.js 20, 22, 23 | 22.12.0 | npm |
-| Python | pyenv | 3.9.1以上, 3.10, 3.11, 3.12, 3.13 | 3.12.8 | <ul><li>venv+pip</li><li>Pipenv</li><li>Poetry</li></ul> |
+| Ansible | venv | 2.17, 2.18 | 2.17.11 | ansible-galaxy |
+| JavaScript | nvm | Node.js 20, 22, 23 | 22.15.0 | npm |
+| Python | pyenv | 3.9.1以上, 3.10, 3.11, 3.12, 3.13 | 3.12.10 | <ul><li>venv+pip</li><li>Pipenv</li><li>Poetry</li></ul> |
 
 ## 実行方法
 まず最初に、macOSのターミナルを開き、本リポジトリをクローンします。
@@ -43,7 +45,7 @@ git clone https://github.com/hotani3/start-code.git
 
 まだgitコマンドがインストール済みでないときは、[Releases](https://github.com/hotani3/start-code/releases)からZIPファイルをダウンロードし、展開します。
 ```sh
-unzip start-code-1.1.2.zip && mv start-code-1.1.2 start-code
+unzip start-code-1.2.0.zip && mv start-code-1.2.0 start-code
 ```
 
 次に、クローンまたはZIP展開したディレクトリに移動します。
@@ -57,9 +59,23 @@ cd start-code
 `-v`オプションで開発・実行環境バージョンが指定可能です。  
 指定しなかった場合は、表2のデフォルトバージョンがインストールされます。
 
+#### Ansible
+```sh
+./macos/install/ansible.sh -v 2.17.11 --python 3.12.10
+```
+
+Ansibleでは`-v`に加え、次の対応表に従って、`--python`オプションでPython実行環境のバージョンを指定してください。  
+`--python`を省略した場合、表2のPythonデフォルトバージョンがインストールされます。
+
+表3: AnsibleとPythonバージョンの対応
+| | Python 3.10 | 3.11 | 3.12 | 3.13 |
+| :--- | :---: | :---: | :---: | :---: |
+| Ansible 2.17 | ✅ | ✅ | ✅ | |
+| Ansible 2.18 | | ✅ | ✅ | ✅ |
+
 #### JavaScript
 ```sh
-./macos/install/javascript-node.sh -v 22.12.0
+./macos/install/javascript-node.sh -v 22.15.0
 ```
 
 JavaScriptでは、`-v`オプションはNode.js実行環境のバージョンです。  
@@ -67,7 +83,7 @@ JavaScriptでは、`-v`オプションはNode.js実行環境のバージョン�
 
 #### Python
 ```sh
-./macos/install/python.sh -v 3.12.8
+./macos/install/python.sh -v 3.12.10
 ```
 
 スクリプト実行直後、次のようにパスワード入力を促されたときは、Macログインユーザーのパスワードを入力してください。
@@ -77,22 +93,22 @@ JavaScriptでは、`-v`オプションはNode.js実行環境のバージョン�
 しばらく待ち、ターミナルに以下のようなログが出力されれば、開発・実行環境のインストールに成功しています。
 ```sh
 [2024-09-03 22:57:35] INFO python.sh: Successfully installed Python!
-[2024-09-03 22:57:36] INFO python.sh: Detected Python 3.12.8
+[2024-09-03 22:57:36] INFO python.sh: Detected Python 3.12.10
 ```
 
 Python標準のvenv+pipではなく、PipenvやPoetryでパッケージ管理を行う場合は、`python.sh`の代わりに、次のスクリプトを実行してください。
 
 #### Pipenv
 ```sh
-./macos/install/python-pipenv.sh -v 3.12.8
+./macos/install/python-pipenv.sh -v 3.12.10
 ```
 
 #### Poetry
 ```sh
-./macos/install/python-poetry.sh -v 3.12.8
+./macos/install/python-poetry.sh -v 3.12.10
 ```
 
-上記の例では、Python 3.12.8がインストールされ、さらにPipenvまたはPoetryがインストールされます。  
+上記の例では、Python 3.12.10がインストールされ、さらにPipenvまたはPoetryがインストールされます。  
 いずれの場合も、`-v`オプションはPython実行環境のバージョンです。PipenvやPoetryのバージョンではないことに注意してください。
 
 なお、Pipenvは`-v`で指定されたバージョンに加えて、`pyenv global`で指定された現在選択中のバージョンにもインストールされます。
@@ -103,6 +119,18 @@ source ~/.zshrc
 ```
 
 最後に、バージョン管理ツールでインストールされたバージョン、および、現在選択中のバージョンを確認することをお勧めします。
+#### Ansible
+```sh
+ls ~/envs
+```
+
+初めてAnsible実行環境をインストールしたときの表示例です。
+```sh
+ansible-2.17.11-on-python-3.12.10
+```
+
+インストールしたバージョンを選択して使用する方法については、[docs/ansible.md](./docs/ansible.md)をご覧ください。
+
 #### JavaScript
 ```sh
 nvm ls
@@ -110,9 +138,9 @@ nvm ls
 
 初めてNode.js実行環境をインストールしたときの表示例です。
 ```sh
-->     v22.12.0
+->     v22.15.0
          system
-default -> 22.12.0 (-> v22.12.0)
+default -> 22.15.0 (-> v22.15.0)
 [後略]
 ```
 
@@ -124,7 +152,7 @@ pyenv versions
 初めてPython実行環境をインストールしたときの表示例です。
 ```sh
   system
-* 3.12.8 (set by /Users/username/.pyenv/version)
+* 3.12.10 (set by /Users/username/.pyenv/version)
 ```
 
 ## 補足説明：追加・更新されるパッケージと設定ファイル
@@ -132,7 +160,7 @@ pyenv versions
 
 加えて、環境変数やプログラム実行パスの設定を行うため、必要に応じて以下の設定ファイルも自動更新されます。
 
-表3: 追加・更新対象のパッケージ・設定ファイル
+表4: 追加・更新対象のパッケージ・設定ファイル
 | プラットフォーム | パッケージ | 設定ファイル |
 | :--- | :--- | :--- |
 | macOS | <ul><li>Xcode Command Line Tools</li><li>Homebrew</li><li>XZ Utils</li></ul> | <ul><li>\~/.zprofile</li><li>\~/.zshrc</li></ul> |

--- a/README_en.md
+++ b/README_en.md
@@ -1,3 +1,4 @@
+![Ansible on macOS](https://github.com/hotani3/start-code/actions/workflows/ansible-on-macos.yml/badge.svg)&emsp;
 ![JavaScript on macOS](https://github.com/hotani3/start-code/actions/workflows/javascript-on-macos.yml/badge.svg)&emsp;
 ![Python on macOS](https://github.com/hotani3/start-code/actions/workflows/python-on-macos.yml/badge.svg)
 
@@ -25,15 +26,16 @@ Table 1: Target Platforms
 | macOS | <ul><li>x86_64 (Intel Chip)</li><li>ARM64 (Apple Silicon)</li></ul> | <ul><li>Ventura (13)</li><li>Sonoma (14)</li><li>Sequoia (15)</li></ul> | zsh |
 
 ## Programming Language
-At present, these scripts are targeted for JavaScript and Python.
+At present, these scripts are targeted for Ansible, JavaScript and Python.
 
 The version control tool and package management tools for each language are as follows. One standard version control tool has been chosen for each language.
 
 Table 2: Target Programming Languages
 | Language | Version Control Tool | Runtime Version | Default Version | Package Management Tool |
 | :--- | :--- | :--- | :--- | :--- |
-| Javascript | nvm | Node.js 20, 22, 23 | 22.12.0 | npm |
-| Python | pyenv | 3.9.1 or higher, 3.10, 3.11, 3.12, 3.13 | 3.12.8 | <ul><li>venv+pip</li><li>Pipenv</li><li>Poetry</li></ul> |
+| Ansible | venv | 2.17, 2.18 | 2.17.11 | ansible-galaxy |
+| Javascript | nvm | Node.js 20, 22, 23 | 22.15.0 | npm |
+| Python | pyenv | 3.9.1 or higher, 3.10, 3.11, 3.12, 3.13 | 3.12.10 | <ul><li>venv+pip</li><li>Pipenv</li><li>Poetry</li></ul> |
 
 ## How to Execute
 First, open the macOS terminal and clone this repository.
@@ -43,7 +45,7 @@ git clone https://github.com/hotani3/start-code.git
 
 If the git command is not installed, download the ZIP file from [Releases](https://github.com/hotani3/start-code/releases) and extract it.
 ```sh
-unzip start-code-1.1.2.zip && mv start-code-1.1.2 start-code
+unzip start-code-1.2.0.zip && mv start-code-1.2.0 start-code
 ```
 
 Next, move to the directory that was cloned or extracted from the ZIP.
@@ -57,9 +59,23 @@ Be sure to run a script while you are in the "start-code" directory.
 You can specify a development or runtime environment version with the `-v` option.  
 If not specified, the default version in Table 2 will be installed.
 
+#### Ansible
+```sh
+./macos/install/ansible.sh -v 2.17.11 --python 3.12.10
+```
+
+In addition to `-v`, in Ansible, specify the version of the Python runtime environment with the `--python` option according to the following table.  
+If `--python` is omitted, the default Python version in Table 2 will be installed.
+
+Table 3: Correspondence between Ansible and Python versions
+| | Python 3.10 | 3.11 | 3.12 | 3.13 |
+| :--- | :---: | :---: | :---: | :---: |
+| Ansible 2.17 | ✅ | ✅ | ✅ | |
+| Ansible 2.18 | | ✅ | ✅ | ✅ |
+
 #### JavaScript
 ```sh
-./macos/install/javascript-node.sh -v 22.12.0
+./macos/install/javascript-node.sh -v 22.15.0
 ```
 
 In JavaScript, the `-v` option is the version of the Node.js runtime environment.  
@@ -67,7 +83,7 @@ In addition to the version number, you can also specify aliases such as `stable`
 
 #### Python
 ```sh
-./macos/install/python.sh -v 3.12.8
+./macos/install/python.sh -v 3.12.10
 ```
 
 Immediately after running the script, if you are prompted to enter a password as shown below, please enter your Mac login user's password.
@@ -77,22 +93,22 @@ Immediately after running the script, if you are prompted to enter a password as
 Wait a moment, and if the following log is output to the terminal, a development or runtime environment has been successfully installed.
 ```sh
 [2024-09-03 22:57:35] INFO python.sh: Successfully installed Python!
-[2024-09-03 22:57:36] INFO python.sh: Detected Python 3.12.8
+[2024-09-03 22:57:36] INFO python.sh: Detected Python 3.12.10
 ```
 
 If you want to manage packages with Pipenv or Poetry instead of Python's standard venv+pip, run the following script instead of `python.sh`.
 
 #### Pipenv
 ```sh
-./macos/install/python-pipenv.sh -v 3.12.8
+./macos/install/python-pipenv.sh -v 3.12.10
 ```
 
 #### Poetry
 ```sh
-./macos/install/python-poetry.sh -v 3.12.8
+./macos/install/python-poetry.sh -v 3.12.10
 ```
 
-In the above examples, Python 3.12.8 will be installed, and additionally, Pipenv or Poetry will also be installed.  
+In the above examples, Python 3.12.10 will be installed, and additionally, Pipenv or Poetry will also be installed.  
 In all cases, the `-v` option is for specifying the Python runtime environment version, not the version of Pipenv or Poetry.
 
 Please note that for Pipenv, it will be installed for both the version specified with `-v` and the currently selected version as specified by `pyenv global`.
@@ -104,6 +120,18 @@ source ~/.zshrc
 ```
 
 Finally, it is preferable to check the versions installed and currently selected with a version control tool.
+#### Ansible
+```sh
+ls ~/envs
+```
+
+Here is an example of what you see when you first install the Ansible runtime environment.
+```sh
+ansible-2.17.11-on-python-3.12.10
+```
+
+Please see [docs/ansible_en.md](./docs/ansible_en.md) for instructions on how to choose and use the version you installed.
+
 #### JavaScript
 ```sh
 nvm ls
@@ -111,9 +139,9 @@ nvm ls
 
 Here is an example of what you see when you first install the Node.js runtime environment.
 ```sh
-->     v22.12.0
+->     v22.15.0
          system
-default -> 22.12.0 (-> v22.12.0)
+default -> 22.15.0 (-> v22.15.0)
 [The rest is ommitted]
 ```
 
@@ -125,7 +153,7 @@ pyenv versions
 Here is an example of what you see when you first install the Python runtime environment.
 ```sh
   system
-* 3.12.8 (set by /Users/username/.pyenv/version)
+* 3.12.10 (set by /Users/username/.pyenv/version)
 ```
 
 ## Additional Notes: Packages and Configuration Files Added or Updated
@@ -133,7 +161,7 @@ When these scripts are executed, the following packages will be automatically do
 
 Additionally, the following configuration files will be automatically updated as necessary to configure environment variables and program execution paths.
 
-Table 3: Packages and Configuration Files to be Added or Updated
+Table 4: Packages and Configuration Files to be Added or Updated
 | Platform | Package | Configuration File |
 | :--- | :--- | :--- |
 | macOS | <ul><li>Xcode Command Line Tools</li><li>Homebrew</li><li>XZ Utils</li></ul> | <ul><li>\~/.zprofile</li><li>\~/.zshrc</li></ul> |

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -1,0 +1,79 @@
+# Ansible 開発ツール使用方法
+
+## Ansible 仮想環境の活性化
+start-codeでは、AnsibleをPython仮想環境にインストールしています。  
+Ansibleの仮想環境は、ホームディレクトリの`envs`ディレクトリ以下に作成されているので、Ansibleが使えるように仮想環境の活性化を行います。
+
+```sh
+source ~/envs/ansible-2.17.11-on-python-3.12.10/bin/activate
+```
+
+活性化後、`ansible`コマンドが使えることを確認します。
+```sh
+ansible --version
+```
+
+バージョンの表示例です。
+> ansible [core 2.17.11]  
+>   config file = None  
+>   configured module search path = ['/Users/username/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']  
+>   ansible python module location = /Users/username/envs/ansible-2.17.11-on-python-3.12.10/lib/python3.12/site-packages/ansible  
+>   ansible collection location = /Users/username/.ansible/collections:/usr/share/ansible/collections  
+>   executable location = /Users/username/envs/ansible-2.17.11-on-python-3.12.10/bin/ansible  
+>   python version = 3.12.10 (main, May  5 2025, 15:25:53) [Clang 14.0.3 (clang-1403.0.22.14.1)] (/Users/username/envs/ansible-2.17.11-on-python-3.12.10/bin/python3)  
+>   jinja version = 3.1.6  
+>   libyaml = True
+
+なお、仮想環境を活性化すると、Pythonも`ansible.sh`実行時に指定したPython実行環境のバージョンに切り替わっています。
+```sh
+python -V
+```
+
+> Python 3.12.10
+
+## Ansible コレクション・ロール管理
+Ansibleで外部ライブラリに相当するコレクションとロールは、`ansible-galaxy`ツールで管理可能です。
+
+しかし、`ansible-galaxy`はデフォルトだと、`~/.ansible/collections`と`~/.ansible/roles`ディレクトリにコレクション・ロールをインストールするため、Ansibleのバージョンやプロジェクト（自作プレイブック・ロール）単位でのコレクション・ロール管理ができません。
+
+プロジェクトごとに個別でコレクション・ロール管理を行うには、`ansible-galaxy`コマンドで`-p`や`--roles-path`オプションを指定して、プロジェクトディレクトリ内の`collections`や`roles`ディレクトリにコレクション・ロールをインストールするようにします。
+```sh
+ansible-galaxy collection install community.kubernetes -p collections
+```
+
+```sh
+ansible-galaxy role install geerlingguy.apache --roles-path roles
+```
+
+コレクション・ロールの依存関係をすべて記載した`requirements.yml`を使う場合は、次のようになります。
+```sh
+ansible-galaxy collection install -r requirements.yml -p collections
+ansible-galaxy role install -r requirements.yml --roles-path roles
+```
+
+プロジェクトディレクトリに以下の内容の`ansible.cfg`を作成すると、`ansible-galaxy`での`-p`や`--roles-path`が省略でき、インストールしたコレクション・ロールがプレイブックから使用可能になります。
+```ini:ansible.cfg
+[defaults]
+# cowsayを無効化
+nocows = True
+# コレクションの検索・インストール先: ./collections/ansible_collections/namespace/collection_name
+collections_path = ./collections
+# ロールの検索・インストール先: ./roles/namespace.rolename
+roles_path = ./roles
+```
+
+この`ansible.cfg`により、コレクションとロールが混在した`requirements.yml`でも、次のように一度にまとめてインストールできるようになります。
+```sh
+ansible-galaxy install -r requirements.yml
+```
+
+## Ansible 仮想環境の非活性化
+Ansibleを使い終わったら、仮想環境を非活性化してください。
+```sh
+deactivate
+```
+
+## 参考情報
+- [Ansible best practices: using project-local collections and roles](https://www.jeffgeerling.com/blog/2020/ansible-best-practices-using-project-local-collections-and-roles)
+- [Galaxy User Guide](https://docs.ansible.com/ansible/latest/galaxy/user_guide.html)
+- [Ansible Configuration Settings](https://docs.ansible.com/ansible/latest/reference_appendices/config.html)

--- a/docs/ansible_en.md
+++ b/docs/ansible_en.md
@@ -1,0 +1,79 @@
+# How to Use Ansible Development Tools
+
+## Activating the Ansible Virtual Environment
+In start-code, Ansible is installed into a Python virtual environment.  
+The Ansible virtual environment is created under the `envs` directory in your home directory, so activate the virtual environment to enable Ansible.
+
+```sh
+source ~/envs/ansible-2.17.11-on-python-3.12.10/bin/activate
+```
+
+After activation, confirm that the `ansible` command is available.
+```sh
+ansible --version
+```
+
+Here is an example of the version output.
+> ansible [core 2.17.11]  
+>   config file = None  
+>   configured module search path = ['/Users/username/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']  
+>   ansible python module location = /Users/username/envs/ansible-2.17.11-on-python-3.12.10/lib/python3.12/site-packages/ansible  
+>   ansible collection location = /Users/username/.ansible/collections:/usr/share/ansible/collections  
+>   executable location = /Users/username/envs/ansible-2.17.11-on-python-3.12.10/bin/ansible  
+>   python version = 3.12.10 (main, May  5 2025, 15:25:53) [Clang 14.0.3 (clang-1403.0.22.14.1)] (/Users/username/envs/ansible-2.17.11-on-python-3.12.10/bin/python3)
+>   jinja version = 3.1.6  
+>   libyaml = True
+
+Also, once the virtual environment is activated, Python switches to the version specified when executing `ansible.sh`.
+```sh
+python -V
+```
+
+> Python 3.12.10
+
+## Managing Ansible Collections and Roles
+In Ansible, collections and roles—which are equivalent to external libraries—can be managed using the `ansible-galaxy` tool.
+
+However, by default, `ansible-galaxy` installs collections and roles into the `~/.ansible/collections` and `~/.ansible/roles` directories, making it difficult to manage collections and roles by Ansible version or project (custom playbooks and roles).
+
+To manage collections and roles separately for each project, use the `-p` or `--roles-path` option with the `ansible-galaxy` command to install them into the `collections` or `roles` directories within the project directory.
+```sh
+ansible-galaxy collection install community.kubernetes -p collections
+```
+
+```sh
+ansible-galaxy role install geerlingguy.apache --roles-path roles
+```
+
+If using a `requirements.yml` file that lists all collection and role dependencies, proceed as follows:
+```sh
+ansible-galaxy collection install -r requirements.yml -p collections
+ansible-galaxy role install -r requirements.yml --roles-path roles
+```
+
+By creating an `ansible.cfg` file in a project directory with the following content, you can omit the `-p` and `--roles-path` options in `ansible-galaxy`, and the installed collections and roles become available from playbooks.
+```ini:ansible.cfg
+[defaults]
+# Disable cowsay
+nocows = True
+# Collection search and installation path: ./collections/ansible_collections/namespace/collection_name
+collections_path = ./collections
+# Role search and installation path: ./roles/namespace.rolename
+roles_path = ./roles
+```
+
+Thanks to this `ansible.cfg`, even a `requirements.yml` file containing a mix of collections and roles can be installed all at once like so:
+```sh
+ansible-galaxy install -r requirements.yml
+```
+
+## Deactivating the Ansible Virtual Environment
+Once you are done using Ansible, deactivate the virtual environment.
+```sh
+deactivate
+```
+
+## Reference Information
+- [Ansible best practices: using project-local collections and roles](https://www.jeffgeerling.com/blog/2020/ansible-best-practices-using-project-local-collections-and-roles)
+- [Galaxy User Guide](https://docs.ansible.com/ansible/latest/galaxy/user_guide.html)
+- [Ansible Configuration Settings](https://docs.ansible.com/ansible/latest/reference_appendices/config.html)

--- a/macos/install/javascript-node.sh
+++ b/macos/install/javascript-node.sh
@@ -17,4 +17,12 @@ echo "[$timestamp] INFO $SCRIPT_NAME $SCRIPT_VERSION: Running on macOS $MACOS_VE
 # nvm.sh requires the git command in Xcode CLT installed by homebrew.sh
 source ./macos/lib/homebrew.sh
 source ./macos/lib/nvm.sh
+
+# Get -v option value as Node.js version number or alias
+while getopts v: OPT
+do
+  case $OPT in
+    v) NODE_VERSION_ALIAS=$OPTARG ;;
+  esac
+done
 source ./macos/lib/nvm-node.sh

--- a/macos/install/python-poetry.sh
+++ b/macos/install/python-poetry.sh
@@ -16,6 +16,14 @@ echo "[$timestamp] INFO $SCRIPT_NAME $SCRIPT_VERSION: Running on macOS $MACOS_VE
 
 source ./macos/lib/homebrew.sh
 source ./macos/lib/pyenv.sh
+
+# Get -v option value as Python version
+while getopts v: OPT
+do
+  case $OPT in
+    v) PYTHON_VERSION=$OPTARG ;;
+  esac
+done
 source ./macos/lib/pyenv-python.sh
 
 # Save current global Python version

--- a/macos/install/python.sh
+++ b/macos/install/python.sh
@@ -16,4 +16,12 @@ echo "[$timestamp] INFO $SCRIPT_NAME $SCRIPT_VERSION: Running on macOS $MACOS_VE
 
 source ./macos/lib/homebrew.sh
 source ./macos/lib/pyenv.sh
+
+# Get -v option value as Python version
+while getopts v: OPT
+do
+  case $OPT in
+    v) PYTHON_VERSION=$OPTARG ;;
+  esac
+done
 source ./macos/lib/pyenv-python.sh

--- a/macos/lib/constants.sh
+++ b/macos/lib/constants.sh
@@ -1,9 +1,10 @@
 #!/bin/zsh
-readonly SCRIPT_VERSION="1.1.2"
-readonly NVM_VERSION="0.40.1"
+readonly SCRIPT_VERSION="1.2.0"
+readonly NVM_VERSION="0.40.2"
 
-readonly DEFAULT_PYTHON_VERSION="3.12.8"
-readonly DEFAULT_NODE_VERSION="22.12.0"
+readonly DEFAULT_NODE_VERSION="22.15.0"
+readonly DEFAULT_PYTHON_VERSION="3.12.10"
+readonly DEFAULT_ANSIBLE_VERSION="2.17.11"
 
 readonly CPU_ARCH=$(uname -m)
 readonly MACOS_VERSION=$(sw_vers -productVersion)

--- a/macos/lib/nvm-node.sh
+++ b/macos/lib/nvm-node.sh
@@ -1,13 +1,5 @@
 #!/bin/zsh
 
-# Get -v option value as Node.js version number or alias
-while getopts v: OPT
-do
-  case $OPT in
-    v) NODE_VERSION_ALIAS=$OPTARG ;;
-  esac
-done
-
 # If not specified in an arg, set default version
 if [ -z "$NODE_VERSION_ALIAS" ]; then
   NODE_VERSION_ALIAS=$DEFAULT_NODE_VERSION

--- a/macos/lib/nvm.sh
+++ b/macos/lib/nvm.sh
@@ -12,7 +12,7 @@ version_cmd='nvm --version'
 install_cmd="curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v$NVM_VERSION/install.sh | bash"
 detect $package_title $detect_cmd $version_cmd false
 if [ $? -ne 0 ]; then
-  echo "# nvm" >> ~/.zshrc
+  echo -n "# nvm" >> ~/.zshrc
   sync
   install $package_title $install_cmd
 

--- a/macos/lib/pyenv-python.sh
+++ b/macos/lib/pyenv-python.sh
@@ -1,13 +1,5 @@
 #!/bin/zsh
 
-# Get -v option value as Python version
-while getopts v: OPT
-do
-  case $OPT in
-    v) PYTHON_VERSION=$OPTARG ;;
-  esac
-done
-
 # If not specified in an arg, set default version
 if [ -z "$PYTHON_VERSION" ]; then
   PYTHON_VERSION=$DEFAULT_PYTHON_VERSION


### PR DESCRIPTION
1. Install Ansible on macOS
2. Add tests on macOS Squoia (arm64) against Ansible, JavaScript and Python
3. Update latest and default versions of Node.js and Python