### PR TITLE
Release v1.2.1

### DIFF
--- a/.github/workflows/ansible-on-macos.yml
+++ b/.github/workflows/ansible-on-macos.yml
@@ -9,14 +9,15 @@ on:
       - main
   schedule:
     - cron: '10 11 * * *'
+  workflow_dispatch:
 
 env:
   # Overwrite the default shell to zsh
   SHELL: /bin/zsh
 
 jobs:
-  test-on-macos-ventura-x86_64:
-    runs-on: macos-13
+  test-on-macos-sonoma-arm64:
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,119 +27,72 @@ jobs:
         shell: zsh {0}
         run: |
           ./macos/install/ansible.sh -v 2.17.0 --python 3.10.0
-      - name: Install Ansible 2.17.0 with Python 3.10.17
+      - name: Install Ansible 2.17.0 with Python 3.10.19
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.0 --python 3.10.17
-      - name: Install Ansible 2.17.0 with Python 3.11.12
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.10.19
+      - name: Install Ansible 2.17.0 with Python 3.11.14
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.0 --python 3.11.12
-      - name: Install Ansible 2.17.0 with Python 3.12.10
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.11.14
+      - name: Install Ansible 2.17.0 with Python 3.12.12
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.0 --python 3.12.10
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.12.12
 
-      # Ansible 2.17.11 against supported Python versions
-      - name: Install Ansible 2.17.11 with Python 3.10.0
+      # Ansible 2.17.14 against supported Python versions
+      - name: Install Ansible 2.17.14 with Python 3.10.0
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.11 --python 3.10.0
-      - name: Install Ansible 2.17.11 with Python 3.10.17
+          ./macos/install/ansible.sh -v 2.17.14 --python 3.10.0
+      - name: Install Ansible 2.17.14 with Python 3.10.19
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.11 --python 3.10.17
-      - name: Install Ansible 2.17.11 with Python 3.11.12
+          ./macos/install/ansible.sh -v 2.17.14 --python 3.10.19
+      - name: Install Ansible 2.17.14 with Python 3.11.14
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.11 --python 3.11.12
-      - name: Install Ansible 2.17.11 with Python 3.12.10
+          ./macos/install/ansible.sh -v 2.17.14 --python 3.11.14
+      - name: Install Ansible 2.17.14 with Python 3.12.12
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.11 --python 3.12.10
+          ./macos/install/ansible.sh -v 2.17.14 --python 3.12.12
 
-      # Ansible 2.18.5 against supported Python versions
-      - name: Install Ansible 2.18.5 with Python 3.11.0
+      # Ansible 2.18.10 against supported Python versions
+      - name: Install Ansible 2.18.10 with Python 3.11.0
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.18.5 --python 3.11.0
-      - name: Install Ansible 2.18.5 with Python 3.11.12
+          ./macos/install/ansible.sh -v 2.18.10 --python 3.11.0
+      - name: Install Ansible 2.18.10 with Python 3.11.14
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.18.5 --python 3.11.12
-      - name: Install Ansible 2.18.5 with Python 3.12.10
+          ./macos/install/ansible.sh -v 2.18.10 --python 3.11.14
+      - name: Install Ansible 2.18.10 with Python 3.12.12
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.18.5 --python 3.12.10
-      - name: Install Ansible 2.18.5 with Python 3.13.3
+          ./macos/install/ansible.sh -v 2.18.10 --python 3.12.12
+      - name: Install Ansible 2.18.10 with Python 3.13.8
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.18.5 --python 3.13.3
-      
-      - name: List all Ansible versions
-        shell: zsh {0}
-        run: |
-          ls ~/envs
+          ./macos/install/ansible.sh -v 2.18.10 --python 3.13.8
 
-  test-on-macos-sonoma-arm64:
-    runs-on: macos-14
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      # Ansible 2.17.0
-      - name: Install Ansible 2.17.0 with Python 3.10.0
+      # Ansible 2.19.3 against supported Python versions
+      - name: Install Ansible 2.19.3 with Python 3.11.0
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.0 --python 3.10.0
-      - name: Install Ansible 2.17.0 with Python 3.10.17
+          ./macos/install/ansible.sh -v 2.19.3 --python 3.11.0
+      - name: Install Ansible 2.19.3 with Python 3.11.14
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.0 --python 3.10.17
-      - name: Install Ansible 2.17.0 with Python 3.11.12
+          ./macos/install/ansible.sh -v 2.19.3 --python 3.11.14
+      - name: Install Ansible 2.19.3 with Python 3.12.12
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.0 --python 3.11.12
-      - name: Install Ansible 2.17.0 with Python 3.12.10
+          ./macos/install/ansible.sh -v 2.19.3 --python 3.12.12
+      - name: Install Ansible 2.19.3 with Python 3.13.8
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.0 --python 3.12.10
-
-      # Ansible 2.17.11
-      - name: Install Ansible 2.17.11 with Python 3.10.0
-        shell: zsh {0}
-        run: |
-          ./macos/install/ansible.sh -v 2.17.11 --python 3.10.0
-      - name: Install Ansible 2.17.11 with Python 3.10.17
-        shell: zsh {0}
-        run: |
-          ./macos/install/ansible.sh -v 2.17.11 --python 3.10.17
-      - name: Install Ansible 2.17.11 with Python 3.11.12
-        shell: zsh {0}
-        run: |
-          ./macos/install/ansible.sh -v 2.17.11 --python 3.11.12
-      - name: Install Ansible 2.17.11 with Python 3.12.10
-        shell: zsh {0}
-        run: |
-          ./macos/install/ansible.sh -v 2.17.11 --python 3.12.10
-
-      # Ansible 2.18.5
-      - name: Install Ansible 2.18.5 with Python 3.11.0
-        shell: zsh {0}
-        run: |
-          ./macos/install/ansible.sh -v 2.18.5 --python 3.11.0
-      - name: Install Ansible 2.18.5 with Python 3.11.12
-        shell: zsh {0}
-        run: |
-          ./macos/install/ansible.sh -v 2.18.5 --python 3.11.12
-      - name: Install Ansible 2.18.5 with Python 3.12.10
-        shell: zsh {0}
-        run: |
-          ./macos/install/ansible.sh -v 2.18.5 --python 3.12.10
-      - name: Install Ansible 2.18.5 with Python 3.13.3
-        shell: zsh {0}
-        run: |
-          ./macos/install/ansible.sh -v 2.18.5 --python 3.13.3
+          ./macos/install/ansible.sh -v 2.19.3 --python 3.13.8
 
       - name: List all Ansible versions
         shell: zsh {0}
@@ -156,54 +110,238 @@ jobs:
         shell: zsh {0}
         run: |
           ./macos/install/ansible.sh -v 2.17.0 --python 3.10.0
-      - name: Install Ansible 2.17.0 with Python 3.10.17
+      - name: Install Ansible 2.17.0 with Python 3.10.19
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.0 --python 3.10.17
-      - name: Install Ansible 2.17.0 with Python 3.11.12
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.10.19
+      - name: Install Ansible 2.17.0 with Python 3.11.14
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.0 --python 3.11.12
-      - name: Install Ansible 2.17.0 with Python 3.12.10
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.11.14
+      - name: Install Ansible 2.17.0 with Python 3.12.12
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.0 --python 3.12.10
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.12.12
 
-      # Ansible 2.17.11
-      - name: Install Ansible 2.17.11 with Python 3.10.0
+      # Ansible 2.17.14
+      - name: Install Ansible 2.17.14 with Python 3.10.0
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.11 --python 3.10.0
-      - name: Install Ansible 2.17.11 with Python 3.10.17
+          ./macos/install/ansible.sh -v 2.17.14 --python 3.10.0
+      - name: Install Ansible 2.17.14 with Python 3.10.19
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.11 --python 3.10.17
-      - name: Install Ansible 2.17.11 with Python 3.11.12
+          ./macos/install/ansible.sh -v 2.17.14 --python 3.10.19
+      - name: Install Ansible 2.17.14 with Python 3.11.14
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.11 --python 3.11.12
-      - name: Install Ansible 2.17.11 with Python 3.12.10
+          ./macos/install/ansible.sh -v 2.17.14 --python 3.11.14
+      - name: Install Ansible 2.17.14 with Python 3.12.12
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.17.11 --python 3.12.10
+          ./macos/install/ansible.sh -v 2.17.14 --python 3.12.12
 
-      # Ansible 2.18.5
-      - name: Install Ansible 2.18.5 with Python 3.11.0
+      # Ansible 2.18.10
+      - name: Install Ansible 2.18.10 with Python 3.11.0
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.18.5 --python 3.11.0
-      - name: Install Ansible 2.18.5 with Python 3.11.12
+          ./macos/install/ansible.sh -v 2.18.10 --python 3.11.0
+      - name: Install Ansible 2.18.10 with Python 3.11.14
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.18.5 --python 3.11.12
-      - name: Install Ansible 2.18.5 with Python 3.12.10
+          ./macos/install/ansible.sh -v 2.18.10 --python 3.11.14
+      - name: Install Ansible 2.18.10 with Python 3.12.12
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.18.5 --python 3.12.10
-      - name: Install Ansible 2.18.5 with Python 3.13.3
+          ./macos/install/ansible.sh -v 2.18.10 --python 3.12.12
+      - name: Install Ansible 2.18.10 with Python 3.13.8
         shell: zsh {0}
         run: |
-          ./macos/install/ansible.sh -v 2.18.5 --python 3.13.3
+          ./macos/install/ansible.sh -v 2.18.10 --python 3.13.8
+
+      # Ansible 2.19.3
+      - name: Install Ansible 2.19.3 with Python 3.11.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.19.3 --python 3.11.0
+      - name: Install Ansible 2.19.3 with Python 3.11.14
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.19.3 --python 3.11.14
+      - name: Install Ansible 2.19.3 with Python 3.12.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.19.3 --python 3.12.12
+      - name: Install Ansible 2.19.3 with Python 3.13.8
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.19.3 --python 3.13.8
+
+      - name: List all Ansible versions
+        shell: zsh {0}
+        run: |
+          ls ~/envs
+
+  test-on-macos-sequoia-x86_64:
+    runs-on: macos-15-intel
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Ansible 2.17.0
+      - name: Install Ansible 2.17.0 with Python 3.10.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.10.0
+      - name: Install Ansible 2.17.0 with Python 3.10.19
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.10.19
+      - name: Install Ansible 2.17.0 with Python 3.11.14
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.11.14
+      - name: Install Ansible 2.17.0 with Python 3.12.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.12.12
+
+      # Ansible 2.17.14
+      - name: Install Ansible 2.17.14 with Python 3.10.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.14 --python 3.10.0
+      - name: Install Ansible 2.17.14 with Python 3.10.19
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.14 --python 3.10.19
+      - name: Install Ansible 2.17.14 with Python 3.11.14
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.14 --python 3.11.14
+      - name: Install Ansible 2.17.14 with Python 3.12.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.14 --python 3.12.12
+
+      # Ansible 2.18.10
+      - name: Install Ansible 2.18.10 with Python 3.11.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.10 --python 3.11.0
+      - name: Install Ansible 2.18.10 with Python 3.11.14
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.10 --python 3.11.14
+      - name: Install Ansible 2.18.10 with Python 3.12.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.10 --python 3.12.12
+      - name: Install Ansible 2.18.10 with Python 3.13.8
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.10 --python 3.13.8
+
+      # Ansible 2.19.3
+      - name: Install Ansible 2.19.3 with Python 3.11.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.19.3 --python 3.11.0
+      - name: Install Ansible 2.19.3 with Python 3.11.14
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.19.3 --python 3.11.14
+      - name: Install Ansible 2.19.3 with Python 3.12.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.19.3 --python 3.12.12
+      - name: Install Ansible 2.19.3 with Python 3.13.8
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.19.3 --python 3.13.8
+
+      - name: List all Ansible versions
+        shell: zsh {0}
+        run: |
+          ls ~/envs
+
+  test-on-macos-tahoe-arm64:
+    runs-on: macos-26
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Ansible 2.17.0
+      - name: Install Ansible 2.17.0 with Python 3.10.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.10.0
+      - name: Install Ansible 2.17.0 with Python 3.10.19
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.10.19
+      - name: Install Ansible 2.17.0 with Python 3.11.14
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.11.14
+      - name: Install Ansible 2.17.0 with Python 3.12.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.0 --python 3.12.12
+
+      # Ansible 2.17.14
+      - name: Install Ansible 2.17.14 with Python 3.10.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.14 --python 3.10.0
+      - name: Install Ansible 2.17.14 with Python 3.10.19
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.14 --python 3.10.19
+      - name: Install Ansible 2.17.14 with Python 3.11.14
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.14 --python 3.11.14
+      - name: Install Ansible 2.17.14 with Python 3.12.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.17.14 --python 3.12.12
+
+      # Ansible 2.18.10
+      - name: Install Ansible 2.18.10 with Python 3.11.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.10 --python 3.11.0
+      - name: Install Ansible 2.18.10 with Python 3.11.14
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.10 --python 3.11.14
+      - name: Install Ansible 2.18.10 with Python 3.12.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.10 --python 3.12.12
+      - name: Install Ansible 2.18.10 with Python 3.13.8
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.18.10 --python 3.13.8
+
+      # Ansible 2.19.3
+      - name: Install Ansible 2.19.3 with Python 3.11.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.19.3 --python 3.11.0
+      - name: Install Ansible 2.19.3 with Python 3.11.14
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.19.3 --python 3.11.14
+      - name: Install Ansible 2.19.3 with Python 3.12.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.19.3 --python 3.12.12
+      - name: Install Ansible 2.19.3 with Python 3.13.8
+        shell: zsh {0}
+        run: |
+          ./macos/install/ansible.sh -v 2.19.3 --python 3.13.8
 
       - name: List all Ansible versions
         shell: zsh {0}

--- a/.github/workflows/javascript-on-macos.yml
+++ b/.github/workflows/javascript-on-macos.yml
@@ -9,14 +9,15 @@ on:
       - main
   schedule:
     - cron: '40 10 * * *'
+  workflow_dispatch:
 
 env:
   # Overwrite the default shell to zsh
   SHELL: /bin/zsh
 
 jobs:
-  test-on-macos-ventura-x86_64:
-    runs-on: macos-13
+  test-on-macos-sonoma-arm64:
+    runs-on: macos-14
     steps:
       # Checkout this repo
       - name: Checkout
@@ -26,18 +27,18 @@ jobs:
         shell: zsh {0}
         run: |
           ./macos/install/javascript-node.sh -v 20.0.0
-      - name: Install Node.js 20.19.1
+      - name: Install Node.js 20.19.5
         shell: zsh {0}
         run: |
-          ./macos/install/javascript-node.sh -v 20.19.1
-      - name: Install Node.js 22.15.0
+          ./macos/install/javascript-node.sh -v 20.19.5
+      - name: Install Node.js 22.20.0
         shell: zsh {0}
         run: |
-          ./macos/install/javascript-node.sh -v 22.15.0
-      - name: Install Node.js 23.11.0
+          ./macos/install/javascript-node.sh -v 22.20.0
+      - name: Install Node.js 24.10.0
         shell: zsh {0}
         run: |
-          ./macos/install/javascript-node.sh -v 23.11.0
+          ./macos/install/javascript-node.sh -v 24.10.0
       - name: List all Node.js versions
         shell: zsh {0}
         run: |
@@ -73,9 +74,9 @@ jobs:
         run: |
           source ~/.zshrc
           nvm ls
-  
-  test-on-macos-sonoma-arm64:
-    runs-on: macos-14
+
+  test-on-macos-sequoia-arm64:
+    runs-on: macos-15
     steps:
       # Checkout this repo
       - name: Checkout
@@ -85,18 +86,18 @@ jobs:
         shell: zsh {0}
         run: |
           ./macos/install/javascript-node.sh -v 20.0.0
-      - name: Install Node.js 20.19.1
+      - name: Install Node.js 20.19.5
         shell: zsh {0}
         run: |
-          ./macos/install/javascript-node.sh -v 20.19.1
-      - name: Install Node.js 22.15.0
+          ./macos/install/javascript-node.sh -v 20.19.5
+      - name: Install Node.js 22.20.0
         shell: zsh {0}
         run: |
-          ./macos/install/javascript-node.sh -v 22.15.0
-      - name: Install Node.js 23.11.0
+          ./macos/install/javascript-node.sh -v 22.20.0
+      - name: Install Node.js 24.10.0
         shell: zsh {0}
         run: |
-          ./macos/install/javascript-node.sh -v 23.11.0
+          ./macos/install/javascript-node.sh -v 24.10.0
       - name: List all Node.js versions
         shell: zsh {0}
         run: |
@@ -107,8 +108,9 @@ jobs:
         run: |
           source ~/.zshrc
           nvm deactivate
-          nvm ls --no-alias | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | while read -r version; do
-            nvm uninstall "$version"
+          versions=($(nvm ls --no-alias | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'))
+          for version in $versions; do
+            nvm uninstall $version
           done
       - name: Install Node.js LTS iron
         shell: zsh {0}
@@ -132,8 +134,8 @@ jobs:
           source ~/.zshrc
           nvm ls
 
-  test-on-macos-sequoia-arm64:
-    runs-on: macos-15
+  test-on-macos-sequoia-x86_64:
+    runs-on: macos-15-intel
     steps:
       # Checkout this repo
       - name: Checkout
@@ -143,18 +145,77 @@ jobs:
         shell: zsh {0}
         run: |
           ./macos/install/javascript-node.sh -v 20.0.0
-      - name: Install Node.js 20.19.1
+      - name: Install Node.js 20.19.5
         shell: zsh {0}
         run: |
-          ./macos/install/javascript-node.sh -v 20.19.1
-      - name: Install Node.js 22.15.0
+          ./macos/install/javascript-node.sh -v 20.19.5
+      - name: Install Node.js 22.20.0
         shell: zsh {0}
         run: |
-          ./macos/install/javascript-node.sh -v 22.15.0
-      - name: Install Node.js 23.11.0
+          ./macos/install/javascript-node.sh -v 22.20.0
+      - name: Install Node.js 24.10.0
         shell: zsh {0}
         run: |
-          ./macos/install/javascript-node.sh -v 23.11.0
+          ./macos/install/javascript-node.sh -v 24.10.0
+      - name: List all Node.js versions
+        shell: zsh {0}
+        run: |
+          source ~/.zshrc
+          nvm ls
+      - name: Uninstall all versions
+        shell: zsh {0}
+        run: |
+          source ~/.zshrc
+          nvm deactivate
+          versions=($(nvm ls --no-alias | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'))
+          for version in $versions; do
+            nvm uninstall $version
+          done
+      - name: Install Node.js LTS iron
+        shell: zsh {0}
+        run: |
+          ./macos/install/javascript-node.sh -v lts/iron
+      - name: Install Node.js LTS jod
+        shell: zsh {0}
+        run: |
+          ./macos/install/javascript-node.sh -v lts/jod
+      - name: Install Node.js LTS latest
+        shell: zsh {0}
+        run: |
+          ./macos/install/javascript-node.sh -v 'lts/*'
+      - name: Install Node.js stable version
+        shell: zsh {0}
+        run: |
+          ./macos/install/javascript-node.sh -v stable
+      - name: List Node.js aliases
+        shell: zsh {0}
+        run: |
+          source ~/.zshrc
+          nvm ls
+
+  test-on-macos-tahoe-arm64:
+    runs-on: macos-26
+    steps:
+      # Checkout this repo
+      - name: Checkout
+        uses: actions/checkout@v4
+      # Run the script using zsh
+      - name: Install Node.js 20.0.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/javascript-node.sh -v 20.0.0
+      - name: Install Node.js 20.19.5
+        shell: zsh {0}
+        run: |
+          ./macos/install/javascript-node.sh -v 20.19.5
+      - name: Install Node.js 22.20.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/javascript-node.sh -v 22.20.0
+      - name: Install Node.js 24.10.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/javascript-node.sh -v 24.10.0
       - name: List all Node.js versions
         shell: zsh {0}
         run: |

--- a/.github/workflows/python-on-macos.yml
+++ b/.github/workflows/python-on-macos.yml
@@ -9,62 +9,13 @@ on:
       - main
   schedule:
     - cron: '40 10 * * *'
+  workflow_dispatch:
 
 env:
   # Overwrite the default shell to zsh
   SHELL: /bin/zsh
 
-jobs:
-  test-on-macos-ventura-x86_64:
-    runs-on: macos-13
-    steps:
-      # Checkout this repo
-      - name: Checkout
-        uses: actions/checkout@v4
-      # Run the script using zsh
-      - name: Install Python 3.9.1
-        shell: zsh {0}
-        run: |
-          ./macos/install/python-pipenv.sh -v 3.9.1
-      - name: Install Python 3.9.22
-        shell: zsh {0}
-        run: |
-          ./macos/install/python-pipenv.sh -v 3.9.22
-      - name: Install Python 3.10.17
-        shell: zsh {0}
-        run: |
-          ./macos/install/python-pipenv.sh -v 3.10.17
-      - name: Install Python 3.11.12
-        shell: zsh {0}
-        run: |
-          ./macos/install/python-pipenv.sh -v 3.11.12
-      - name: Install Python 3.12.10
-        shell: zsh {0}
-        run: |
-          ./macos/install/python-pipenv.sh -v 3.12.10
-      - name: Install Python 3.13.3
-        shell: zsh {0}
-        run: |
-          ./macos/install/python-pipenv.sh -v 3.13.3
-      - name: List all Python versions
-        shell: zsh {0}
-        run: |
-          source ~/.zshrc
-          pyenv versions
-      - name: Install Poetry bound with Python 3.9.1
-        shell: zsh {0}
-        run: |
-          ./macos/install/python-poetry.sh -v 3.9.1
-      - name: Uninstall Poetry
-        shell: zsh {0}
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 - --uninstall
-          unlink $HOME/.local/bin/poetry
-      - name: Install Poetry bound with Python 3.13.3
-        shell: zsh {0}
-        run: |
-          ./macos/install/python-poetry.sh -v 3.13.3
- 
+jobs: 
   test-on-macos-sonoma-arm64:
     runs-on: macos-14
     steps:
@@ -77,26 +28,30 @@ jobs:
         shell: zsh {0}
         run: |
           ./macos/install/python-pipenv.sh -v 3.9.1
-      - name: Install Python 3.9.22
+      - name: Install Python 3.9.24
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.9.22
-      - name: Install Python 3.10.17
+          ./macos/install/python-pipenv.sh -v 3.9.24
+      - name: Install Python 3.10.19
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.10.17
-      - name: Install Python 3.11.12
+          ./macos/install/python-pipenv.sh -v 3.10.19
+      - name: Install Python 3.11.14
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.11.12
-      - name: Install Python 3.12.10
+          ./macos/install/python-pipenv.sh -v 3.11.14
+      - name: Install Python 3.12.12
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.12.10
-      - name: Install Python 3.13.3
+          ./macos/install/python-pipenv.sh -v 3.12.12
+      - name: Install Python 3.13.8
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.13.3
+          ./macos/install/python-pipenv.sh -v 3.13.8
+      - name: Install Python 3.14.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.14.0
       - name: List all Python versions
         shell: zsh {0}
         run: |
@@ -111,10 +66,10 @@ jobs:
         run: |
           curl -sSL https://install.python-poetry.org | python3 - --uninstall
           unlink $HOME/.local/bin/poetry
-      - name: Install Poetry bound with Python 3.13.3
+      - name: Install Poetry bound with Python 3.14.0
         shell: zsh {0}
         run: |
-          ./macos/install/python-poetry.sh -v 3.13.3
+          ./macos/install/python-poetry.sh -v 3.14.0
 
   test-on-macos-sequoia-arm64:
     runs-on: macos-15
@@ -128,26 +83,30 @@ jobs:
         shell: zsh {0}
         run: |
           ./macos/install/python-pipenv.sh -v 3.9.1
-      - name: Install Python 3.9.22
+      - name: Install Python 3.9.24
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.9.22
-      - name: Install Python 3.10.17
+          ./macos/install/python-pipenv.sh -v 3.9.24
+      - name: Install Python 3.10.19
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.10.17
-      - name: Install Python 3.11.12
+          ./macos/install/python-pipenv.sh -v 3.10.19
+      - name: Install Python 3.11.14
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.11.12
-      - name: Install Python 3.12.10
+          ./macos/install/python-pipenv.sh -v 3.11.14
+      - name: Install Python 3.12.12
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.12.10
-      - name: Install Python 3.13.3
+          ./macos/install/python-pipenv.sh -v 3.12.12
+      - name: Install Python 3.13.8
         shell: zsh {0}
         run: |
-          ./macos/install/python-pipenv.sh -v 3.13.3
+          ./macos/install/python-pipenv.sh -v 3.13.8
+      - name: Install Python 3.14.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.14.0
       - name: List all Python versions
         shell: zsh {0}
         run: |
@@ -162,7 +121,117 @@ jobs:
         run: |
           curl -sSL https://install.python-poetry.org | python3 - --uninstall
           unlink $HOME/.local/bin/poetry
-      - name: Install Poetry bound with Python 3.13.3
+      - name: Install Poetry bound with Python 3.14.0
         shell: zsh {0}
         run: |
-          ./macos/install/python-poetry.sh -v 3.13.3
+          ./macos/install/python-poetry.sh -v 3.14.0
+
+  test-on-macos-sequoia-x86_64:
+    runs-on: macos-15-intel
+    steps:
+      # Checkout this repo
+      - name: Checkout
+        uses: actions/checkout@v4
+      # Run the script using zsh
+      # 3.9.1 is the first version that supports Apple Silicon
+      - name: Install Python 3.9.1
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.9.1
+      - name: Install Python 3.9.24
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.9.24
+      - name: Install Python 3.10.19
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.10.19
+      - name: Install Python 3.11.14
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.11.14
+      - name: Install Python 3.12.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.12.12
+      - name: Install Python 3.13.8
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.13.8
+      - name: Install Python 3.14.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.14.0
+      - name: List all Python versions
+        shell: zsh {0}
+        run: |
+          source ~/.zshrc
+          pyenv versions
+      - name: Install Poetry bound with Python 3.9.1
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-poetry.sh -v 3.9.1
+      - name: Uninstall Poetry
+        shell: zsh {0}
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 - --uninstall
+          unlink $HOME/.local/bin/poetry
+      - name: Install Poetry bound with Python 3.14.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-poetry.sh -v 3.14.0
+
+  test-on-macos-tahoe-arm64:
+    runs-on: macos-26
+    steps:
+      # Checkout this repo
+      - name: Checkout
+        uses: actions/checkout@v4
+      # Run the script using zsh
+      # 3.9.1 is the first version that supports Apple Silicon
+      - name: Install Python 3.9.1
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.9.1
+      - name: Install Python 3.9.24
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.9.24
+      - name: Install Python 3.10.19
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.10.19
+      - name: Install Python 3.11.14
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.11.14
+      - name: Install Python 3.12.12
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.12.12
+      - name: Install Python 3.13.8
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.13.8
+      - name: Install Python 3.14.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-pipenv.sh -v 3.14.0
+      - name: List all Python versions
+        shell: zsh {0}
+        run: |
+          source ~/.zshrc
+          pyenv versions
+      - name: Install Poetry bound with Python 3.9.1
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-poetry.sh -v 3.9.1
+      - name: Uninstall Poetry
+        shell: zsh {0}
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 - --uninstall
+          unlink $HOME/.local/bin/poetry
+      - name: Install Poetry bound with Python 3.14.0
+        shell: zsh {0}
+        run: |
+          ./macos/install/python-poetry.sh -v 3.14.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here is English version of [README](./README_en.md).
 表1: 対象プラットフォーム
 | プラットフォーム | CPUアーキテクチャー | OSバージョン | シェル |
 | :--- | :--- | :--- | :--- |
-| macOS | <ul><li>x86_64 (Intel Chip)</li><li>ARM64 (Apple Silicon)</li></ul> | <ul><li>Ventura (13)</li><li>Sonoma (14)</li><li>Sequoia (15)</li></ul> | zsh |
+| macOS | <ul><li>x86_64 (Intel Chip)</li><li>ARM64 (Apple Silicon)</li></ul> | <ul><li>Sonoma (14)</li><li>Sequoia (15)</li><li>Tahoe (26)</li></ul> | zsh |
 
 ## プログラミング言語
 現時点で、本スクリプトが対象としているプログラミング言語は、Ansible, JavaScript, Pythonです。
@@ -33,9 +33,9 @@ Here is English version of [README](./README_en.md).
 表2: 対象プログラミング言語
 | 言語 | バージョン管理ツール | 実行環境バージョン | デフォルトバージョン | パッケージ管理ツール |
 | :--- | :--- | :--- | :--- | :--- |
-| Ansible | venv | 2.17, 2.18 | 2.17.11 | ansible-galaxy |
-| JavaScript | nvm | Node.js 20, 22, 23 | 22.15.0 | npm |
-| Python | pyenv | 3.9.1以上, 3.10, 3.11, 3.12, 3.13 | 3.12.10 | <ul><li>venv+pip</li><li>Pipenv</li><li>Poetry</li></ul> |
+| Ansible | venv | 2.17-19 | 2.18.10 | ansible-galaxy |
+| JavaScript | nvm | Node.js 20, 22, 24 | 22.20.0 | npm |
+| Python | pyenv | 3.9.1以上, 3.10-14 | 3.12.12 | <ul><li>venv+pip</li><li>Pipenv</li><li>Poetry</li></ul> |
 
 ## 実行方法
 まず最初に、macOSのターミナルを開き、本リポジトリをクローンします。
@@ -45,7 +45,7 @@ git clone https://github.com/hotani3/start-code.git
 
 まだgitコマンドがインストール済みでないときは、[Releases](https://github.com/hotani3/start-code/releases)からZIPファイルをダウンロードし、展開します。
 ```sh
-unzip start-code-1.2.0.zip && mv start-code-1.2.0 start-code
+unzip start-code-1.2.1.zip && mv start-code-1.2.1 start-code
 ```
 
 次に、クローンまたはZIP展開したディレクトリに移動します。
@@ -61,7 +61,7 @@ cd start-code
 
 #### Ansible
 ```sh
-./macos/install/ansible.sh -v 2.17.11 --python 3.12.10
+./macos/install/ansible.sh -v 2.18.10 --python 3.12.12
 ```
 
 Ansibleでは`-v`に加え、次の対応表に従って、`--python`オプションでPython実行環境のバージョンを指定してください。  
@@ -72,10 +72,11 @@ Ansibleでは`-v`に加え、次の対応表に従って、`--python`オプシ�
 | :--- | :---: | :---: | :---: | :---: |
 | Ansible 2.17 | ✅ | ✅ | ✅ | |
 | Ansible 2.18 | | ✅ | ✅ | ✅ |
+| Ansible 2.19 | | ✅ | ✅ | ✅ |
 
 #### JavaScript
 ```sh
-./macos/install/javascript-node.sh -v 22.15.0
+./macos/install/javascript-node.sh -v 22.20.0
 ```
 
 JavaScriptでは、`-v`オプションはNode.js実行環境のバージョンです。  
@@ -83,7 +84,7 @@ JavaScriptでは、`-v`オプションはNode.js実行環境のバージョン�
 
 #### Python
 ```sh
-./macos/install/python.sh -v 3.12.10
+./macos/install/python.sh -v 3.12.12
 ```
 
 スクリプト実行直後、次のようにパスワード入力を促されたときは、Macログインユーザーのパスワードを入力してください。
@@ -92,23 +93,23 @@ JavaScriptでは、`-v`オプションはNode.js実行環境のバージョン�
 
 しばらく待ち、ターミナルに以下のようなログが出力されれば、開発・実行環境のインストールに成功しています。
 ```sh
-[2024-09-03 22:57:35] INFO python.sh: Successfully installed Python!
-[2024-09-03 22:57:36] INFO python.sh: Detected Python 3.12.10
+[2025-10-12 22:57:35] INFO python.sh: Successfully installed Python!
+[2025-10-12 22:57:36] INFO python.sh: Detected Python 3.12.12
 ```
 
 Python標準のvenv+pipではなく、PipenvやPoetryでパッケージ管理を行う場合は、`python.sh`の代わりに、次のスクリプトを実行してください。
 
 #### Pipenv
 ```sh
-./macos/install/python-pipenv.sh -v 3.12.10
+./macos/install/python-pipenv.sh -v 3.12.12
 ```
 
 #### Poetry
 ```sh
-./macos/install/python-poetry.sh -v 3.12.10
+./macos/install/python-poetry.sh -v 3.12.12
 ```
 
-上記の例では、Python 3.12.10がインストールされ、さらにPipenvまたはPoetryがインストールされます。  
+上記の例では、Python 3.12.12がインストールされ、さらにPipenvまたはPoetryがインストールされます。  
 いずれの場合も、`-v`オプションはPython実行環境のバージョンです。PipenvやPoetryのバージョンではないことに注意してください。
 
 なお、Pipenvは`-v`で指定されたバージョンに加えて、`pyenv global`で指定された現在選択中のバージョンにもインストールされます。
@@ -126,7 +127,7 @@ ls ~/envs
 
 初めてAnsible実行環境をインストールしたときの表示例です。
 ```sh
-ansible-2.17.11-on-python-3.12.10
+ansible-2.18.10-on-python-3.12.12
 ```
 
 インストールしたバージョンを選択して使用する方法については、[docs/ansible.md](./docs/ansible.md)をご覧ください。
@@ -138,9 +139,9 @@ nvm ls
 
 初めてNode.js実行環境をインストールしたときの表示例です。
 ```sh
-->     v22.15.0
+->     v22.20.0
          system
-default -> 22.15.0 (-> v22.15.0)
+default -> 22.20.0 (-> v22.20.0)
 [後略]
 ```
 
@@ -152,7 +153,7 @@ pyenv versions
 初めてPython実行環境をインストールしたときの表示例です。
 ```sh
   system
-* 3.12.10 (set by /Users/username/.pyenv/version)
+* 3.12.12 (set by /Users/username/.pyenv/version)
 ```
 
 ## 補足説明：追加・更新されるパッケージと設定ファイル

--- a/README_en.md
+++ b/README_en.md
@@ -23,7 +23,7 @@ Currently, the only platform that has been tested is macOS.
 Table 1: Target Platforms
 | Platform | CPU Architecture | OS Version | Shell |
 | :--- | :--- | :--- | :--- |
-| macOS | <ul><li>x86_64 (Intel Chip)</li><li>ARM64 (Apple Silicon)</li></ul> | <ul><li>Ventura (13)</li><li>Sonoma (14)</li><li>Sequoia (15)</li></ul> | zsh |
+| macOS | <ul><li>x86_64 (Intel Chip)</li><li>ARM64 (Apple Silicon)</li></ul> | <ul><li>Sonoma (14)</li><li>Sequoia (15)</li><li>Tahoe (26)</li></ul> | zsh |
 
 ## Programming Language
 At present, these scripts are targeted for Ansible, JavaScript and Python.
@@ -33,9 +33,9 @@ The version control tool and package management tools for each language are as f
 Table 2: Target Programming Languages
 | Language | Version Control Tool | Runtime Version | Default Version | Package Management Tool |
 | :--- | :--- | :--- | :--- | :--- |
-| Ansible | venv | 2.17, 2.18 | 2.17.11 | ansible-galaxy |
-| Javascript | nvm | Node.js 20, 22, 23 | 22.15.0 | npm |
-| Python | pyenv | 3.9.1 or higher, 3.10, 3.11, 3.12, 3.13 | 3.12.10 | <ul><li>venv+pip</li><li>Pipenv</li><li>Poetry</li></ul> |
+| Ansible | venv | 2.17-19 | 2.18.10 | ansible-galaxy |
+| Javascript | nvm | Node.js 20, 22, 24 | 22.20.0 | npm |
+| Python | pyenv | 3.9.1 or higher, 3.10-14 | 3.12.12 | <ul><li>venv+pip</li><li>Pipenv</li><li>Poetry</li></ul> |
 
 ## How to Execute
 First, open the macOS terminal and clone this repository.
@@ -45,7 +45,7 @@ git clone https://github.com/hotani3/start-code.git
 
 If the git command is not installed, download the ZIP file from [Releases](https://github.com/hotani3/start-code/releases) and extract it.
 ```sh
-unzip start-code-1.2.0.zip && mv start-code-1.2.0 start-code
+unzip start-code-1.2.1.zip && mv start-code-1.2.1 start-code
 ```
 
 Next, move to the directory that was cloned or extracted from the ZIP.
@@ -61,7 +61,7 @@ If not specified, the default version in Table 2 will be installed.
 
 #### Ansible
 ```sh
-./macos/install/ansible.sh -v 2.17.11 --python 3.12.10
+./macos/install/ansible.sh -v 2.18.10 --python 3.12.12
 ```
 
 In addition to `-v`, in Ansible, specify the version of the Python runtime environment with the `--python` option according to the following table.  
@@ -72,10 +72,11 @@ Table 3: Correspondence between Ansible and Python versions
 | :--- | :---: | :---: | :---: | :---: |
 | Ansible 2.17 | ✅ | ✅ | ✅ | |
 | Ansible 2.18 | | ✅ | ✅ | ✅ |
+| Ansible 2.19 | | ✅ | ✅ | ✅ |
 
 #### JavaScript
 ```sh
-./macos/install/javascript-node.sh -v 22.15.0
+./macos/install/javascript-node.sh -v 22.20.0
 ```
 
 In JavaScript, the `-v` option is the version of the Node.js runtime environment.  
@@ -83,7 +84,7 @@ In addition to the version number, you can also specify aliases such as `stable`
 
 #### Python
 ```sh
-./macos/install/python.sh -v 3.12.10
+./macos/install/python.sh -v 3.12.12
 ```
 
 Immediately after running the script, if you are prompted to enter a password as shown below, please enter your Mac login user's password.
@@ -92,23 +93,23 @@ Immediately after running the script, if you are prompted to enter a password as
 
 Wait a moment, and if the following log is output to the terminal, a development or runtime environment has been successfully installed.
 ```sh
-[2024-09-03 22:57:35] INFO python.sh: Successfully installed Python!
-[2024-09-03 22:57:36] INFO python.sh: Detected Python 3.12.10
+[2025-10-12 22:57:35] INFO python.sh: Successfully installed Python!
+[2025-10-12 22:57:36] INFO python.sh: Detected Python 3.12.12
 ```
 
 If you want to manage packages with Pipenv or Poetry instead of Python's standard venv+pip, run the following script instead of `python.sh`.
 
 #### Pipenv
 ```sh
-./macos/install/python-pipenv.sh -v 3.12.10
+./macos/install/python-pipenv.sh -v 3.12.12
 ```
 
 #### Poetry
 ```sh
-./macos/install/python-poetry.sh -v 3.12.10
+./macos/install/python-poetry.sh -v 3.12.12
 ```
 
-In the above examples, Python 3.12.10 will be installed, and additionally, Pipenv or Poetry will also be installed.  
+In the above examples, Python 3.12.12 will be installed, and additionally, Pipenv or Poetry will also be installed.  
 In all cases, the `-v` option is for specifying the Python runtime environment version, not the version of Pipenv or Poetry.
 
 Please note that for Pipenv, it will be installed for both the version specified with `-v` and the currently selected version as specified by `pyenv global`.
@@ -127,7 +128,7 @@ ls ~/envs
 
 Here is an example of what you see when you first install the Ansible runtime environment.
 ```sh
-ansible-2.17.11-on-python-3.12.10
+ansible-2.18.10-on-python-3.12.12
 ```
 
 Please see [docs/ansible_en.md](./docs/ansible_en.md) for instructions on how to choose and use the version you installed.
@@ -139,9 +140,9 @@ nvm ls
 
 Here is an example of what you see when you first install the Node.js runtime environment.
 ```sh
-->     v22.15.0
+->     v22.20.0
          system
-default -> 22.15.0 (-> v22.15.0)
+default -> 22.20.0 (-> v22.20.0)
 [The rest is ommitted]
 ```
 
@@ -153,7 +154,7 @@ pyenv versions
 Here is an example of what you see when you first install the Python runtime environment.
 ```sh
   system
-* 3.12.10 (set by /Users/username/.pyenv/version)
+* 3.12.12 (set by /Users/username/.pyenv/version)
 ```
 
 ## Additional Notes: Packages and Configuration Files Added or Updated

--- a/docs/ansible.md
+++ b/docs/ansible.md
@@ -5,7 +5,7 @@ start-codeでは、AnsibleをPython仮想環境にインストールしていま
 Ansibleの仮想環境は、ホームディレクトリの`envs`ディレクトリ以下に作成されているので、Ansibleが使えるように仮想環境の活性化を行います。
 
 ```sh
-source ~/envs/ansible-2.17.11-on-python-3.12.10/bin/activate
+source ~/envs/ansible-2.18.10-on-python-3.12.12/bin/activate
 ```
 
 活性化後、`ansible`コマンドが使えることを確認します。
@@ -14,13 +14,13 @@ ansible --version
 ```
 
 バージョンの表示例です。
-> ansible [core 2.17.11]  
+> ansible [core 2.18.10]  
 >   config file = None  
 >   configured module search path = ['/Users/username/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']  
->   ansible python module location = /Users/username/envs/ansible-2.17.11-on-python-3.12.10/lib/python3.12/site-packages/ansible  
+>   ansible python module location = /Users/username/envs/ansible-2.18.10-on-python-3.12.12/lib/python3.12/site-packages/ansible  
 >   ansible collection location = /Users/username/.ansible/collections:/usr/share/ansible/collections  
->   executable location = /Users/username/envs/ansible-2.17.11-on-python-3.12.10/bin/ansible  
->   python version = 3.12.10 (main, May  5 2025, 15:25:53) [Clang 14.0.3 (clang-1403.0.22.14.1)] (/Users/username/envs/ansible-2.17.11-on-python-3.12.10/bin/python3)  
+>   executable location = /Users/username/envs/ansible-2.18.10-on-python-3.12.12/bin/ansible  
+>   python version = 3.12.12 (main, Oct 13 2025, 14:14:27) [Clang 15.0.0 (clang-1500.3.9.4)] (/Users/username/envs/ansible-2.18.10-on-python-3.12.12/bin/python3)  
 >   jinja version = 3.1.6  
 >   libyaml = True
 
@@ -29,7 +29,7 @@ ansible --version
 python -V
 ```
 
-> Python 3.12.10
+> Python 3.12.12
 
 ## Ansible コレクション・ロール管理
 Ansibleで外部ライブラリに相当するコレクションとロールは、`ansible-galaxy`ツールで管理可能です。

--- a/docs/ansible_en.md
+++ b/docs/ansible_en.md
@@ -5,7 +5,7 @@ In start-code, Ansible is installed into a Python virtual environment.
 The Ansible virtual environment is created under the `envs` directory in your home directory, so activate the virtual environment to enable Ansible.
 
 ```sh
-source ~/envs/ansible-2.17.11-on-python-3.12.10/bin/activate
+source ~/envs/ansible-2.18.10-on-python-3.12.12/bin/activate
 ```
 
 After activation, confirm that the `ansible` command is available.
@@ -14,13 +14,13 @@ ansible --version
 ```
 
 Here is an example of the version output.
-> ansible [core 2.17.11]  
+> ansible [core 2.18.10]  
 >   config file = None  
 >   configured module search path = ['/Users/username/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']  
->   ansible python module location = /Users/username/envs/ansible-2.17.11-on-python-3.12.10/lib/python3.12/site-packages/ansible  
+>   ansible python module location = /Users/username/envs/ansible-2.18.10-on-python-3.12.12/lib/python3.12/site-packages/ansible  
 >   ansible collection location = /Users/username/.ansible/collections:/usr/share/ansible/collections  
->   executable location = /Users/username/envs/ansible-2.17.11-on-python-3.12.10/bin/ansible  
->   python version = 3.12.10 (main, May  5 2025, 15:25:53) [Clang 14.0.3 (clang-1403.0.22.14.1)] (/Users/username/envs/ansible-2.17.11-on-python-3.12.10/bin/python3)
+>   executable location = /Users/username/envs/ansible-2.18.10-on-python-3.12.12/bin/ansible  
+>   python version = 3.12.12 (main, Oct 13 2025, 14:14:27) [Clang 15.0.0 (clang-1500.3.9.4)] (/Users/username/envs/ansible-2.18.10-on-python-3.12.12/bin/python3)  
 >   jinja version = 3.1.6  
 >   libyaml = True
 
@@ -29,7 +29,7 @@ Also, once the virtual environment is activated, Python switches to the version 
 python -V
 ```
 
-> Python 3.12.10
+> Python 3.12.12
 
 ## Managing Ansible Collections and Roles
 In Ansible, collections and roles—which are equivalent to external libraries—can be managed using the `ansible-galaxy` tool.

--- a/macos/lib/constants.sh
+++ b/macos/lib/constants.sh
@@ -1,10 +1,10 @@
 #!/bin/zsh
-readonly SCRIPT_VERSION="1.2.0"
-readonly NVM_VERSION="0.40.2"
+readonly SCRIPT_VERSION="1.2.1"
+readonly NVM_VERSION="0.40.3"
 
-readonly DEFAULT_NODE_VERSION="22.15.0"
-readonly DEFAULT_PYTHON_VERSION="3.12.10"
-readonly DEFAULT_ANSIBLE_VERSION="2.17.11"
+readonly DEFAULT_NODE_VERSION="22.20.0"
+readonly DEFAULT_PYTHON_VERSION="3.12.12"
+readonly DEFAULT_ANSIBLE_VERSION="2.18.10"
 
 readonly CPU_ARCH=$(uname -m)
 readonly MACOS_VERSION=$(sw_vers -productVersion)

--- a/macos/lib/functions.sh
+++ b/macos/lib/functions.sh
@@ -47,7 +47,7 @@ function assert_ansible_version() {
   local timestamp=""
 
   # Refs: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
-  if [[ ! $version =~ ^2\.(17|18)\.[0-9]+$ ]]; then
+  if [[ ! $version =~ ^2\.(17|18|19)\.[0-9]+$ ]]; then
     timestamp=$(date "+%Y-%m-%d %H:%M:%S")
     echo "[$timestamp] ERROR $SCRIPT_NAME: Unsupported Ansible version: $version" >&2
     exit 1
@@ -60,15 +60,15 @@ function assert_ansible_and_python_version() {
   local timestamp=""
 
   # Refs: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
-  # If Ansible version is 2.17, Python version sholud be 3.10-12
-  # If Ansible version is 2.18, Python version sholud be 3.11-13
+  # If Ansible version is 2.17, Python version should be 3.10-12
+  # If Ansible version is 2.18 or 2.19, Python version should be 3.11-13
   if [[ $ansible_version =~ ^2\.17\.[0-9]+$ ]]; then
     if [[ ! $python_version =~ ^3\.(10|11|12)\.[0-9]+$ ]]; then
       timestamp=$(date "+%Y-%m-%d %H:%M:%S")
       echo "[$timestamp] ERROR $SCRIPT_NAME: Ansible $ansible_version requires Python 3.10-12" >&2
       exit 1
     fi
-  elif [[ $ansible_version =~ ^2\.18\.[0-9]+$ ]]; then
+  elif [[ $ansible_version =~ ^2\.(18|19)\.[0-9]+$ ]]; then
     if [[ ! $python_version =~ ^3\.(11|12|13)\.[0-9]+$ ]]; then
       timestamp=$(date "+%Y-%m-%d %H:%M:%S")
       echo "[$timestamp] ERROR $SCRIPT_NAME: Ansible $ansible_version requires Python 3.11-13" >&2


### PR DESCRIPTION
1. Drop support for macOS Ventura and add support for Tahoe
2. Support Ansible 2.19
3. Update latest and default versions of Ansible, Node.js and Python

